### PR TITLE
Added to_negra()

### DIFF
--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -163,11 +163,16 @@ impl<N: fmt::Display, T: fmt::Display, W: fmt::Display> fmt::Display for PMCFG<N
     }
 }
 
-pub fn evaluate<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Composition<T>>) -> Composition<T> {
+pub fn evaluate<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Composition<T>>)
+        -> Composition<T>
+{
     evaluate_pos(term_map, vec![])
 }
 
-pub fn evaluate_pos<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Composition<T>>, address: Vec<usize>) -> Composition<T> {
+pub fn evaluate_pos<T>(term_map: &BTreeMap<Vec<usize>, Composition<T>>, address: Vec<usize>)
+        -> Composition<T>
+    where T: Clone + fmt::Debug,
+{
     let unexpanded_composition = &term_map.get(&address).unwrap().composition;
     let mut expanded_nonterminals: BTreeMap<_, Vec<Vec<VarT<T>>>> = BTreeMap::new();
     let mut expanded_composition = Vec::new();
@@ -209,7 +214,11 @@ pub fn evaluate_pos<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Compo
     Composition::from(expanded_composition)
 }
 
-pub fn to_term<K: Clone + cmp::Ord, H: Clone, T: Clone, W>(tree_map: &BTreeMap<K, PMCFGRule<H, T, W>>) -> (BTreeMap<K, Composition<T>>, BTreeMap<K, H>) {
+pub fn to_term<K, H, T, W>(tree_map: &BTreeMap<K, PMCFGRule<H, T, W>>)
+        -> (BTreeMap<K, Composition<T>>, BTreeMap<K, H>)
+    where K: Clone + cmp::Ord,
+          H: Clone, T: Clone,
+{
     let mut term_map = BTreeMap::new();
     let mut head_map = BTreeMap::new();
 

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -209,15 +209,17 @@ pub fn evaluate_pos<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Compo
     Composition::from(expanded_composition)
 }
 
-pub fn to_term<K: Clone + cmp::Ord, V: Clone, A, B>(tree_map: &BTreeMap<K, PMCFGRule<A, V, B>>) -> BTreeMap<K, Composition<V>> {
+pub fn to_term<K: Clone + cmp::Ord, H: Clone, T: Clone, W>(tree_map: &BTreeMap<K, PMCFGRule<H, T, W>>) -> (BTreeMap<K, Composition<T>>, BTreeMap<K, H>) {
     let mut term_map = BTreeMap::new();
+    let mut head_map = BTreeMap::new();
 
     for (address, rule) in tree_map {
-        let &PMCFGRule { head: _, tail: _, ref composition, weight: _ } = rule;
+        let &PMCFGRule { ref head, tail: _, ref composition, weight: _ } = rule;
         term_map.insert(address.clone(), composition.clone());
+        head_map.insert(address.clone(), head.clone());
     }
 
-    term_map
+    (term_map, head_map)
 }
 
 #[cfg(test)]

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -235,6 +235,50 @@ pub fn to_term<K, H, T, W>(tree_map: &BTreeMap<K, PMCFGRule<H, T, W>>)
 mod tests {
     use super::*;
     use self::VarT::{Var, T};
+    use std::str::FromStr;
+
+    pub fn example_tree_map() -> BTreeMap<Vec<usize>, PMCFGRule<String, char, usize>> {
+        let mut tree_map: BTreeMap<Vec<usize>, _> = BTreeMap::new();
+
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "S -> [[Var 0 0, Var 1 0, Var 0 1, Var 1 1]] (A, B) # 1"
+        ).unwrap());
+        tree_map.insert(vec![0], PMCFGRule::from_str(
+            "A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 0], PMCFGRule::from_str(
+            "A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 0, 0], PMCFGRule::from_str(
+            "A -> [[], []] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 0, 1], PMCFGRule::from_str(
+            "a -> [[T a]] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 0, 2], PMCFGRule::from_str(
+            "c -> [[T c]] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 1], PMCFGRule::from_str(
+            "a -> [[T a]] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 2], PMCFGRule::from_str(
+            "c -> [[T c]] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![1], PMCFGRule::from_str(
+            "B -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (B, b, d) # 1"
+        ).unwrap());
+        tree_map.insert(vec![1, 0], PMCFGRule::from_str(
+            "B -> [[], []] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![1, 1], PMCFGRule::from_str(
+            "b -> [[T b]] () # 1"
+        ).unwrap());
+        tree_map.insert(vec![1, 2], PMCFGRule::from_str(
+            "d -> [[T d]] () # 1"
+        ).unwrap());
+
+        tree_map
+    }
 
     #[test]
     fn test_evaluate() {

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -295,6 +295,15 @@ mod tests {
         evaluate(&term_map);
     }
 
+    pub fn to_dummy_pmcfg_rule<N, T>(head: N, composition: Composition<T>) -> PMCFGRule<N, T, usize> {
+        PMCFGRule {
+            head,
+            tail: vec![],
+            composition,
+            weight: 0,
+        }
+    }
+
     #[test]
     fn test_to_term() {
         let compos0 = Composition::from(vec![
@@ -310,30 +319,20 @@ mod tests {
         ]);
 
         let mut tree_map = BTreeMap::new();
-        tree_map.insert(vec![], PMCFGRule {
-            head: 0,
-            tail: vec![],
-            composition: compos0.clone(),
-            weight: 0.5
-        });
-        tree_map.insert(vec![0], PMCFGRule {
-            head: 1,
-            tail: vec![],
-            composition: compos1.clone(),
-            weight: 1.5
-        });
-        tree_map.insert(vec![0, 1], PMCFGRule {
-            head: 2,
-            tail: vec![],
-            composition: compos2.clone(),
-            weight: 2.5
-        });
+        tree_map.insert(vec![], to_dummy_pmcfg_rule("A", compos0.clone()));
+        tree_map.insert(vec![0], to_dummy_pmcfg_rule("B", compos1.clone()));
+        tree_map.insert(vec![0, 1], to_dummy_pmcfg_rule("C", compos2.clone()));
 
         let mut term_map = BTreeMap::new();
         term_map.insert(vec![], compos0);
         term_map.insert(vec![0], compos1);
         term_map.insert(vec![0, 1], compos2);
 
-        assert_eq!(term_map, to_term(&tree_map));
+        let mut head_map = BTreeMap::new();
+        head_map.insert(vec![], "A");
+        head_map.insert(vec![0], "B");
+        head_map.insert(vec![0, 1], "C");
+
+        assert_eq!((term_map, head_map), to_term(&tree_map));
     }
 }

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -282,48 +282,12 @@ mod tests {
 
     #[test]
     fn test_evaluate() {
-        let mut term_map: BTreeMap<Vec<usize>, _> = BTreeMap::new();
-        term_map.insert(vec![], Composition::from(vec![
-            vec![Var(0, 0), Var(1, 0), Var(0, 1), Var(1, 1)]
-        ]));
-        term_map.insert(vec![0], Composition::from(vec![
-            vec![Var(1, 0), Var(0, 0)],
-            vec![Var(2, 0), Var(0, 1)]
-        ]));
-        term_map.insert(vec![0, 0], Composition::from(vec![
-            vec![Var(1, 0), Var(0, 0)],
-            vec![Var(2, 0), Var(0, 1)]
-        ]));
-        term_map.insert(vec![0, 0, 0], Composition::from(vec![
-            vec![],
-            vec![]
-        ]));
-        term_map.insert(vec![0, 0, 1], Composition::from(vec![
-            vec![T('a')]
-        ]));
-        term_map.insert(vec![0, 0, 2], Composition::from(vec![
-            vec![T('c')]
-        ]));
-        term_map.insert(vec![0, 1], Composition::from(vec![
-            vec![T('a')]
-        ]));
-        term_map.insert(vec![0, 2], Composition::from(vec![
-            vec![T('c')]
-        ]));
-        term_map.insert(vec![1], Composition::from(vec![
-            vec![Var(1, 0), Var(0, 0)],
-            vec![Var(2, 0), Var(0, 1)]
-        ]));
-        term_map.insert(vec![1, 0], Composition::from(vec![
-            vec![],
-            vec![]
-        ]));
-        term_map.insert(vec![1, 1], Composition::from(vec![
-            vec![T('b')]
-        ]));
-        term_map.insert(vec![1, 2], Composition::from(vec![
-            vec![T('d')]
-        ]));
+        let tree_map = example_tree_map();
+        let mut term_map = BTreeMap::new();
+
+        for (address, PMCFGRule { head: _, tail: _, composition, weight: _ }) in tree_map {
+            term_map.insert(address, composition);
+        }
 
         let expanded_compos = Composition::from(vec![
             vec![T('a'), T('a'), T('b'), T('c'), T('c'), T('d')]
@@ -348,43 +312,37 @@ mod tests {
         evaluate(&term_map);
     }
 
-    pub fn to_dummy_pmcfg_rule<N, T>(head: N, composition: Composition<T>) -> PMCFGRule<N, T, usize> {
-        PMCFGRule {
-            head,
-            tail: vec![],
-            composition,
-            weight: 0,
-        }
-    }
-
     #[test]
     fn test_to_term() {
-        let compos0 = Composition::from(vec![
-            vec![Var(0, 0), T("a"), Var(0, 1), T("b")]
-        ]);
-        let compos1 = Composition::from(vec![
-            vec![Var(1, 0)],
-            vec![T("c")]
-        ]);
-        let compos2 = Composition::from(vec![
-            vec![],
-            vec![]
-        ]);
+        let mut tree_map: BTreeMap<_, PMCFGRule<String, char, usize>> = BTreeMap::new();
 
-        let mut tree_map = BTreeMap::new();
-        tree_map.insert(vec![], to_dummy_pmcfg_rule("A", compos0.clone()));
-        tree_map.insert(vec![0], to_dummy_pmcfg_rule("B", compos1.clone()));
-        tree_map.insert(vec![0, 1], to_dummy_pmcfg_rule("C", compos2.clone()));
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "A -> [[Var 0 0, T a, Var 0 1, T b]] (B) # 1"
+        ).unwrap());
+        tree_map.insert(vec![0], PMCFGRule::from_str(
+            "B -> [[Var 1 0], [T c]] (C) # 1"
+        ).unwrap());
+        tree_map.insert(vec![0, 1], PMCFGRule::from_str(
+            "C -> [[], []] () # 1"
+        ).unwrap());
 
         let mut term_map = BTreeMap::new();
-        term_map.insert(vec![], compos0);
-        term_map.insert(vec![0], compos1);
-        term_map.insert(vec![0, 1], compos2);
+        term_map.insert(vec![], Composition::from(vec![
+            vec![Var(0, 0), T('a'), Var(0, 1), T('b')]
+        ]));
+        term_map.insert(vec![0], Composition::from(vec![
+            vec![Var(1, 0)],
+            vec![T('c')]
+        ]));
+        term_map.insert(vec![0, 1], Composition::from(vec![
+            vec![],
+            vec![]
+        ]));
 
         let mut head_map = BTreeMap::new();
-        head_map.insert(vec![], "A");
-        head_map.insert(vec![0], "B");
-        head_map.insert(vec![0, 1], "C");
+        head_map.insert(vec![], String::from("A"));
+        head_map.insert(vec![0], String::from("B"));
+        head_map.insert(vec![0, 1], String::from("C"));
 
         assert_eq!((term_map, head_map), to_term(&tree_map));
     }

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -206,6 +207,17 @@ pub fn evaluate_pos<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Compo
     }
 
     Composition::from(expanded_composition)
+}
+
+pub fn to_term<K: Clone + cmp::Ord, V: Clone, A, B>(tree_map: &BTreeMap<K, PMCFGRule<A, V, B>>) -> BTreeMap<K, Composition<V>> {
+    let mut term_map = BTreeMap::new();
+
+    for (address, rule) in tree_map {
+        let &PMCFGRule { head: _, tail: _, ref composition, weight: _ } = rule;
+        term_map.insert(address.clone(), composition.clone());
+    }
+
+    term_map
 }
 
 #[cfg(test)]

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -292,4 +292,46 @@ mod tests {
 
         evaluate(&term_map);
     }
+
+    #[test]
+    fn test_to_term() {
+        let compos0 = Composition::from(vec![
+            vec![Var(0, 0), T("a"), Var(0, 1), T("b")]
+        ]);
+        let compos1 = Composition::from(vec![
+            vec![Var(1, 0)],
+            vec![T("c")]
+        ]);
+        let compos2 = Composition::from(vec![
+            vec![],
+            vec![]
+        ]);
+
+        let mut tree_map = BTreeMap::new();
+        tree_map.insert(vec![], PMCFGRule {
+            head: 0,
+            tail: vec![],
+            composition: compos0.clone(),
+            weight: 0.5
+        });
+        tree_map.insert(vec![0], PMCFGRule {
+            head: 1,
+            tail: vec![],
+            composition: compos1.clone(),
+            weight: 1.5
+        });
+        tree_map.insert(vec![0, 1], PMCFGRule {
+            head: 2,
+            tail: vec![],
+            composition: compos2.clone(),
+            weight: 2.5
+        });
+
+        let mut term_map = BTreeMap::new();
+        term_map.insert(vec![], compos0);
+        term_map.insert(vec![0], compos1);
+        term_map.insert(vec![0, 1], compos2);
+
+        assert_eq!(term_map, to_term(&tree_map));
+    }
 }

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -217,45 +217,45 @@ mod tests {
     fn test_evaluate() {
         let mut term_map: BTreeMap<Vec<usize>, _> = BTreeMap::new();
         term_map.insert(vec![], Composition::from(vec![
-                vec![Var(0,0), Var(1,0), Var(0,1), Var(1,1)]
+            vec![Var(0, 0), Var(1, 0), Var(0, 1), Var(1, 1)]
         ]));
         term_map.insert(vec![0], Composition::from(vec![
-                vec![Var(1,0), Var(0,0)],
-                vec![Var(2,0), Var(0,1)]
+            vec![Var(1, 0), Var(0, 0)],
+            vec![Var(2, 0), Var(0, 1)]
         ]));
-        term_map.insert(vec![0,0], Composition::from(vec![
-                vec![Var(1,0), Var(0,0)],
-                vec![Var(2,0), Var(0,1)]
+        term_map.insert(vec![0, 0], Composition::from(vec![
+            vec![Var(1, 0), Var(0, 0)],
+            vec![Var(2, 0), Var(0, 1)]
         ]));
-        term_map.insert(vec![0,0,0], Composition::from(vec![
-                vec![],
-                vec![]
+        term_map.insert(vec![0, 0, 0], Composition::from(vec![
+            vec![],
+            vec![]
         ]));
-        term_map.insert(vec![0,0,1], Composition::from(vec![
-                vec![T('a')]
+        term_map.insert(vec![0, 0, 1], Composition::from(vec![
+            vec![T('a')]
         ]));
-        term_map.insert(vec![0,0,2], Composition::from(vec![
-                vec![T('c')]
+        term_map.insert(vec![0, 0, 2], Composition::from(vec![
+            vec![T('c')]
         ]));
-        term_map.insert(vec![0,1], Composition::from(vec![
-                vec![T('a')]
+        term_map.insert(vec![0, 1], Composition::from(vec![
+            vec![T('a')]
         ]));
-        term_map.insert(vec![0,2], Composition::from(vec![
-                vec![T('c')]
+        term_map.insert(vec![0, 2], Composition::from(vec![
+            vec![T('c')]
         ]));
         term_map.insert(vec![1], Composition::from(vec![
-                vec![Var(1,0), Var(0,0)],
-                vec![Var(2,0), Var(0,1)]
+            vec![Var(1, 0), Var(0, 0)],
+            vec![Var(2, 0), Var(0, 1)]
         ]));
-        term_map.insert(vec![1,0], Composition::from(vec![
-                vec![],
-                vec![]
+        term_map.insert(vec![1, 0], Composition::from(vec![
+            vec![],
+            vec![]
         ]));
-        term_map.insert(vec![1,1], Composition::from(vec![
-                vec![T('b')]
+        term_map.insert(vec![1, 1], Composition::from(vec![
+            vec![T('b')]
         ]));
-        term_map.insert(vec![1,2], Composition::from(vec![
-                vec![T('d')]
+        term_map.insert(vec![1, 2], Composition::from(vec![
+            vec![T('d')]
         ]));
 
         let expanded_compos = Composition::from(vec![
@@ -272,10 +272,10 @@ mod tests {
     fn test_evaluate_invalid_composition() {
         let mut term_map: BTreeMap<Vec<usize>, _> = BTreeMap::new();
         term_map.insert(vec![], Composition::from(vec![
-                vec![Var(0,0), Var(0,1)]
+            vec![Var(0, 0), Var(0, 1)]
         ]));
         term_map.insert(vec![0], Composition::from(vec![
-                vec![T('a')]
+            vec![T('a')]
         ]));
 
         evaluate(&term_map);

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -344,4 +344,27 @@ mod tests {
 
         assert_eq!((term_map, head_map), to_term(&tree_map));
     }
+
+    #[test]
+    fn test_to_term_inverse() {
+        let tree_map = example_tree_map();
+        let (term_map, head_map) = to_term(&tree_map);
+        let mut reconstructed_tree_map = GornTree::new();
+
+        for (address, composition) in term_map {
+            let head = head_map.get(&address).unwrap().clone();
+            reconstructed_tree_map.insert(address, PMCFGRule {
+                head, tail: vec![], composition, weight: 0
+            });
+        }
+
+        for (address, rule) in tree_map {
+            let PMCFGRule { head: ref orig_head, tail: _, composition: ref orig_composition, weight: _ } =
+                rule;
+            let &PMCFGRule { ref head, tail: _, ref composition, weight: _ } =
+                reconstructed_tree_map.get(&address).unwrap();
+            assert_eq!(orig_head, head);
+            assert_eq!(orig_composition, composition);
+        }
+    }
 }

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -6,6 +6,8 @@ use std::marker::PhantomData;
 mod from_str;
 // mod relabel;
 
+pub mod negra;
+
 /// Variable or terminal symbol in an MCFG.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum VarT<T> {
@@ -206,42 +208,6 @@ pub fn evaluate_pos<T: Clone + fmt::Debug>(term_map: &BTreeMap<Vec<usize>, Compo
     Composition::from(expanded_composition)
 }
 
-pub fn identify_terminals<A: Clone>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>) -> (BTreeMap<Vec<usize>, Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>) {
-    let mut identified_tree_map = BTreeMap::new();
-    let mut terminal_map = BTreeMap::new();
-
-    for (address, composition) in tree_map {
-        let vec_compos = &composition.composition;
-        let mut identified_compos = Vec::new();
-        let mut compos_var_pos = 0;
-
-        for component in vec_compos {
-            let mut identified_compon = Vec::new();
-
-            for variable in component {
-                match variable {
-                    &VarT::Var(x, y) => {
-                        identified_compon.push(VarT::Var(x, y));
-                    },
-                    &VarT::T(ref terminal) => {
-                        let terminal_id = (address.clone(), compos_var_pos);
-                        identified_compon.push(VarT::T(terminal_id.clone()));
-                        terminal_map.insert(terminal_id, terminal.clone());
-                    },
-                };
-
-                compos_var_pos += 1;
-            }
-
-            identified_compos.push(identified_compon);
-        }
-
-        identified_tree_map.insert(address.clone(), Composition::from(identified_compos));
-    }
-
-    (identified_tree_map, terminal_map)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,40 +279,5 @@ mod tests {
         ]));
 
         evaluate(&term_map);
-    }
-
-    #[test]
-    fn test_identify_terminals() {
-        let mut tree_map = BTreeMap::new();
-        tree_map.insert(vec![], Composition::from(vec![
-            vec![Var(0,0), T("a"), Var(0,1), T("b")]
-        ]));
-        tree_map.insert(vec![0], Composition::from(vec![
-            vec![Var(1,0)],
-            vec![T("c")]
-        ]));
-        tree_map.insert(vec![1,0], Composition::from(vec![
-            vec![T("d")]
-        ]));
-
-        let mut identified_tree_map = BTreeMap::new();
-        identified_tree_map.insert(vec![], Composition::from(vec![
-            vec![Var(0,0), T((vec![], 1)), Var(0,1), T((vec![], 3))]
-        ]));
-        identified_tree_map.insert(vec![0], Composition::from(vec![
-            vec![Var(1,0)],
-            vec![T((vec![0], 1))]
-        ]));
-        identified_tree_map.insert(vec![1,0], Composition::from(vec![
-            vec![T((vec![1,0], 0))]
-        ]));
-
-        let mut terminal_map = BTreeMap::new();
-        terminal_map.insert((vec![], 1), "a");
-        terminal_map.insert((vec![], 3), "b");
-        terminal_map.insert((vec![0], 1), "c");
-        terminal_map.insert((vec![1,0], 0), "d");
-
-        assert_eq!((identified_tree_map, terminal_map), identify_terminals(&tree_map));
     }
 }

--- a/src/pmcfg/mod.rs
+++ b/src/pmcfg/mod.rs
@@ -221,8 +221,7 @@ pub fn to_term<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
     let mut term_map = GornTree::new();
     let mut head_map = GornTree::new();
 
-    for (address, rule) in tree_map {
-        let &PMCFGRule { ref head, tail: _, ref composition, weight: _ } = rule;
+    for (address, &PMCFGRule { ref head, tail: _, ref composition, weight: _ }) in tree_map {
         term_map.insert(address.clone(), composition.clone());
         head_map.insert(address.clone(), head.clone());
     }

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -218,6 +218,40 @@ mod tests {
     }
 
     #[test]
+    fn test_identify_terminals_inverse() {
+        let (tree_map, _) = to_term(&example_tree_map());
+        let (identified_tree_map, terminal_map) = identify_terminals(&tree_map);
+        let mut unidentified_tree_map = GornTree::new();
+
+        for (address, composition) in identified_tree_map {
+            let mut unidentified_compos = Vec::new();
+
+            for component in composition.composition {
+                let mut unidentified_compon: Vec<VarT<char>> = Vec::new();
+
+                for variable in component {
+                    match variable {
+                        VarT::Var(x, y) => {
+                            unidentified_compon.push(VarT::Var(x, y));
+                        },
+                        VarT::T(terminal_id) => {
+                            unidentified_compon.push(
+                                VarT::T(terminal_map.get(&terminal_id).unwrap().clone())
+                            );
+                        },
+                    }
+                }
+
+                unidentified_compos.push(unidentified_compon);
+            }
+
+            unidentified_tree_map.insert(address, Composition::from(unidentified_compos));
+        }
+
+        assert_eq!(tree_map, unidentified_tree_map);
+    }
+
+    #[test]
     fn test_to_negra_vector() {
         let tree_map = example_tree_map();
         let negra_vector = vec![

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -1,7 +1,10 @@
 use super::*;
 use std::collections::{BTreeMap, LinkedList};
 
-pub fn identify_terminals<A: Clone>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>) -> (BTreeMap<Vec<usize>, Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>) {
+pub fn identify_terminals<A>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>)
+        -> (BTreeMap<Vec<usize>, Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>)
+    where A: Clone,
+{
     let mut identified_tree_map = BTreeMap::new();
     let mut terminal_map = BTreeMap::new();
 
@@ -37,8 +40,13 @@ pub fn identify_terminals<A: Clone>(tree_map: &BTreeMap<Vec<usize>, Composition<
     (identified_tree_map, terminal_map)
 }
 
-pub fn to_negra_vector<H: Clone + ToString, T: Clone + ToString, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>) -> Vec<(String, String, usize)> {
+pub fn to_negra_vector<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>)
+        -> Vec<(String, String, usize)>
+    where H: Clone + ToString,
+          T: Clone + ToString,
+{
     let (term_map, nonterminal_map) = to_term(&tree_map);
+    // TODO: Enforce negra grammar restrictions
     let (identified_tree_map, terminal_map) = identify_terminals(&term_map);
     let evaluated_compos = evaluate(&identified_tree_map);
 
@@ -83,7 +91,9 @@ pub fn to_negra_vector<H: Clone + ToString, T: Clone + ToString, W>(tree_map: &B
     negra_vector
 }
 
-fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>, usize)>, finished_map: &BTreeMap<Vec<usize>, usize>, rule_counter: &mut usize) -> usize {
+fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>, usize)>, finished_map: &BTreeMap<Vec<usize>, usize>, rule_counter: &mut usize)
+        -> usize
+{
     if let Some(rule_number) = finished_map.get(address) {
         return *rule_number
     }

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::collections::{BTreeMap, LinkedList};
+use std::collections::{BTreeMap, VecDeque};
 
 pub fn identify_terminals<A>(tree_map: &GornTree<Composition<A>>)
         -> (GornTree<Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>)
@@ -67,7 +67,7 @@ pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
     let evaluated_compos = evaluate(&identified_tree_map);
 
     let mut negra_vector = Vec::new();
-    let mut rule_queue = LinkedList::new();
+    let mut rule_queue = VecDeque::new();
     let mut finished_map = GornTree::new();
     let mut rule_counter = 0;
 
@@ -107,7 +107,7 @@ pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
     negra_vector
 }
 
-fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>, usize)>, finished_map: &GornTree<usize>, rule_counter: &mut usize)
+fn get_rule_number(address: &Vec<usize>, rule_queue: &mut VecDeque<(Vec<usize>, usize)>, finished_map: &GornTree<usize>, rule_counter: &mut usize)
         -> usize
 {
     if let Some(rule_number) = finished_map.get(address) {

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -135,11 +135,11 @@ pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
                     let parent_number = if let None = parent_address.pop() {
                         panic!("Terminals must have a nonterminal-only rule as their parent!");
                     } else {
-                        get_rule_number(&parent_address, &mut rule_queue, &mut rule_number_map,
+                        get_rule_number(parent_address, &mut rule_queue, &mut rule_number_map,
                                         &mut rule_counter)
                     };
                     negra_vector.push((terminal_symbol.to_string(), rule_label.to_string(), parent_number));
-                }
+                },
             }
         }
     }
@@ -150,7 +150,7 @@ pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
         let parent_number = if let None = parent_address.pop() {
             0
         } else {
-            get_rule_number(&parent_address, &mut rule_queue, &mut rule_number_map, &mut rule_counter)
+            get_rule_number(parent_address, &mut rule_queue, &mut rule_number_map, &mut rule_counter)
         };
 
         let rule_label = nonterminal_map.get(&address).unwrap();
@@ -160,10 +160,10 @@ pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
     negra_vector
 }
 
-fn get_rule_number(address: &Vec<usize>, rule_queue: &mut VecDeque<(Vec<usize>, usize)>, rule_number_map: &mut GornTree<usize>, rule_counter: &mut usize)
+fn get_rule_number(address: Vec<usize>, rule_queue: &mut VecDeque<(Vec<usize>, usize)>, rule_number_map: &mut GornTree<usize>, rule_counter: &mut usize)
         -> usize
 {
-    if let Some(rule_number) = rule_number_map.get(address) {
+    if let Some(rule_number) = rule_number_map.get(&address) {
         return *rule_number
     }
 
@@ -171,7 +171,7 @@ fn get_rule_number(address: &Vec<usize>, rule_queue: &mut VecDeque<(Vec<usize>, 
     *rule_counter = *rule_counter + 1;
 
     rule_number_map.insert(address.clone(), rule_number.clone());
-    rule_queue.push_back((address.clone(), rule_number));
+    rule_queue.push_back((address, rule_number));
     rule_number
 }
 

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -40,6 +40,22 @@ pub fn identify_terminals<A>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>)
     (identified_tree_map, terminal_map)
 }
 
+pub fn to_negra<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>, sentence_num: usize)
+        -> String
+    where H: Clone + ToString,
+          T: Clone + ToString,
+{
+    let negra_vector = to_negra_vector(&tree_map);
+    let mut output = format!("#BOS {}\n", sentence_num);
+
+    for (symbol1, symbol2, number) in negra_vector {
+        output.push_str(&format!("{}\t{}\t{}\n", symbol1, symbol2, number));
+    }
+
+    output.push_str(&format!("#EOS {}", sentence_num));
+    output
+}
+
 pub fn to_negra_vector<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>)
         -> Vec<(String, String, usize)>
     where H: Clone + ToString,

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -180,6 +180,7 @@ mod tests {
     use super::*;
     use super::super::tests::*;
     use self::VarT::{Var, T};
+    use std::str::FromStr;
 
     #[test]
     fn test_identify_terminals() {
@@ -233,5 +234,44 @@ mod tests {
         ];
 
         assert_eq!(negra_vector, to_negra_vector(&tree_map));
+    }
+
+    #[test]
+    fn test_meets_negra_criteria() {
+        let mut tree_map: GornTree<PMCFGRule<String, char, usize>> = GornTree::new();
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "S -> [[T a, T b]] () #1"
+        ).unwrap());
+
+        assert_eq!(false, meets_negra_criteria(&tree_map));
+
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "S -> [[Var 0 0, T a]] (A) #1"
+        ).unwrap());
+
+        assert_eq!(false, meets_negra_criteria(&tree_map));
+
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "S -> [[Var 0 0], [Var 1 0]] (a, b) #1"
+        ).unwrap());
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "A -> [[T a]] () #1"
+        ).unwrap());
+
+        assert_eq!(true, meets_negra_criteria(&tree_map));
+    }
+
+    #[test]
+    #[should_panic(expected =
+        "The given tree does not meet the negra criteria! All rules must either consist \
+         only of nonterminals or of exactly one terminal symbol."
+    )]
+    fn test_to_negra_violated_criteria() {
+        let mut tree_map: GornTree<PMCFGRule<String, char, usize>> = GornTree::new();
+        tree_map.insert(vec![], PMCFGRule::from_str(
+            "S -> [[T a, T b]] () #1"
+        ).unwrap());
+
+        to_negra(&tree_map, 0);
     }
 }

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -141,6 +141,7 @@ fn get_rule_number(address: &Vec<usize>, rule_queue: &mut VecDeque<(Vec<usize>, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::tests::*;
     use self::VarT::{Var, T};
 
     #[test]
@@ -176,5 +177,24 @@ mod tests {
         terminal_map.insert(TermId::from((vec![0, 1], 0)), "d");
 
         assert_eq!((identified_tree_map, terminal_map), identify_terminals(&tree_map));
+    }
+
+    #[test]
+    fn test_to_negra_vector() {
+        let tree_map = example_tree_map();
+        let negra_vector = vec![
+            (String::from("a"), String::from("a"), 1),
+            (String::from("a"), String::from("a"), 2),
+            (String::from("b"), String::from("b"), 3),
+            (String::from("c"), String::from("c"), 1),
+            (String::from("c"), String::from("c"), 2),
+            (String::from("d"), String::from("d"), 3),
+            (String::from("#1"), String::from("A"), 4),
+            (String::from("#2"), String::from("A"), 1),
+            (String::from("#3"), String::from("B"), 4),
+            (String::from("#4"), String::from("S"), 0)
+        ];
+
+        assert_eq!(negra_vector, to_negra_vector(&tree_map));
     }
 }

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -1,11 +1,11 @@
 use super::*;
 use std::collections::{BTreeMap, LinkedList};
 
-pub fn identify_terminals<A>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>)
-        -> (BTreeMap<Vec<usize>, Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>)
+pub fn identify_terminals<A>(tree_map: &GornTree<Composition<A>>)
+        -> (GornTree<Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>)
     where A: Clone,
 {
-    let mut identified_tree_map = BTreeMap::new();
+    let mut identified_tree_map = GornTree::new();
     let mut terminal_map = BTreeMap::new();
 
     for (address, composition) in tree_map {
@@ -40,7 +40,7 @@ pub fn identify_terminals<A>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>)
     (identified_tree_map, terminal_map)
 }
 
-pub fn to_negra<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>, sentence_num: usize)
+pub fn to_negra<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>, sentence_num: usize)
         -> String
     where H: Clone + ToString,
           T: Clone + ToString,
@@ -56,7 +56,7 @@ pub fn to_negra<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>, se
     output
 }
 
-pub fn to_negra_vector<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, W>>)
+pub fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>)
         -> Vec<(String, String, usize)>
     where H: Clone + ToString,
           T: Clone + ToString,
@@ -68,7 +68,7 @@ pub fn to_negra_vector<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, 
 
     let mut negra_vector = Vec::new();
     let mut rule_queue = LinkedList::new();
-    let mut finished_map = BTreeMap::new();
+    let mut finished_map = GornTree::new();
     let mut rule_counter = 0;
 
     for component in evaluated_compos.composition {
@@ -107,7 +107,7 @@ pub fn to_negra_vector<H, T, W>(tree_map: &BTreeMap<Vec<usize>, PMCFGRule<H, T, 
     negra_vector
 }
 
-fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>, usize)>, finished_map: &BTreeMap<Vec<usize>, usize>, rule_counter: &mut usize)
+fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>, usize)>, finished_map: &GornTree<usize>, rule_counter: &mut usize)
         -> usize
 {
     if let Some(rule_number) = finished_map.get(address) {
@@ -123,11 +123,11 @@ fn get_rule_number(address: &Vec<usize>, rule_queue: &mut LinkedList<(Vec<usize>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use VarT::{Var, T};
+    use self::VarT::{Var, T};
 
     #[test]
     fn test_identify_terminals() {
-        let mut tree_map = BTreeMap::new();
+        let mut tree_map = GornTree::new();
         tree_map.insert(vec![], Composition::from(vec![
             vec![Var(0, 0), T("a"), Var(0, 1), T("b")]
         ]));
@@ -139,7 +139,7 @@ mod tests {
             vec![T("d")]
         ]));
 
-        let mut identified_tree_map = BTreeMap::new();
+        let mut identified_tree_map = GornTree::new();
         identified_tree_map.insert(vec![], Composition::from(vec![
             vec![Var(0, 0), T((vec![], 1)), Var(0, 1), T((vec![], 3))]
         ]));

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -52,7 +52,7 @@ mod tests {
             vec![Var(1, 0)],
             vec![T("c")]
         ]));
-        tree_map.insert(vec![1, 0], Composition::from(vec![
+        tree_map.insert(vec![0, 1], Composition::from(vec![
             vec![T("d")]
         ]));
 
@@ -64,15 +64,15 @@ mod tests {
             vec![Var(1, 0)],
             vec![T((vec![0], 1))]
         ]));
-        identified_tree_map.insert(vec![1, 0], Composition::from(vec![
-            vec![T((vec![1, 0], 0))]
+        identified_tree_map.insert(vec![0, 1], Composition::from(vec![
+            vec![T((vec![0, 1], 0))]
         ]));
 
         let mut terminal_map = BTreeMap::new();
         terminal_map.insert((vec![], 1), "a");
         terminal_map.insert((vec![], 3), "b");
         terminal_map.insert((vec![0], 1), "c");
-        terminal_map.insert((vec![1, 0], 0), "d");
+        terminal_map.insert((vec![0, 1], 0), "d");
 
         assert_eq!((identified_tree_map, terminal_map), identify_terminals(&tree_map));
     }

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -52,19 +52,19 @@ pub fn identify_terminals<A>(tree_map: &GornTree<Composition<A>>)
     (identified_tree_map, terminal_map)
 }
 
-pub fn to_negra<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>, sentence_num: usize)
+pub fn to_negra<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>, sentence_id: usize)
         -> String
     where H: Clone + ToString,
           T: Clone + ToString,
 {
     let negra_vector = to_negra_vector(&tree_map);
-    let mut output = format!("#BOS {}\n", sentence_num);
+    let mut output = format!("#BOS {}\n", sentence_id);
 
-    for (symbol1, symbol2, number) in negra_vector {
-        output.push_str(&format!("{}\t{}\t{}\n", symbol1, symbol2, number));
+    for (word, tag, parent) in negra_vector {
+        output.push_str(&format!("{}\t{}\t--\t--\t{}\n", word, tag, parent));
     }
 
-    output.push_str(&format!("#EOS {}", sentence_num));
+    output.push_str(&format!("#EOS {}", sentence_id));
     output
 }
 

--- a/src/pmcfg/negra.rs
+++ b/src/pmcfg/negra.rs
@@ -1,0 +1,79 @@
+use super::{VarT, Composition};
+use std::collections::BTreeMap;
+
+pub fn identify_terminals<A: Clone>(tree_map: &BTreeMap<Vec<usize>, Composition<A>>) -> (BTreeMap<Vec<usize>, Composition<(Vec<usize>, usize)>>, BTreeMap<(Vec<usize>, usize), A>) {
+    let mut identified_tree_map = BTreeMap::new();
+    let mut terminal_map = BTreeMap::new();
+
+    for (address, composition) in tree_map {
+        let vec_compos = &composition.composition;
+        let mut identified_compos = Vec::new();
+        let mut compos_var_pos = 0;
+
+        for component in vec_compos {
+            let mut identified_compon = Vec::new();
+
+            for variable in component {
+                match variable {
+                    &VarT::Var(x, y) => {
+                        identified_compon.push(VarT::Var(x, y));
+                    },
+                    &VarT::T(ref terminal) => {
+                        let terminal_id = (address.clone(), compos_var_pos);
+                        identified_compon.push(VarT::T(terminal_id.clone()));
+                        terminal_map.insert(terminal_id, terminal.clone());
+                    },
+                };
+
+                compos_var_pos += 1;
+            }
+
+            identified_compos.push(identified_compon);
+        }
+
+        identified_tree_map.insert(address.clone(), Composition::from(identified_compos));
+    }
+
+    (identified_tree_map, terminal_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use VarT::{Var, T};
+
+    #[test]
+    fn test_identify_terminals() {
+        let mut tree_map = BTreeMap::new();
+        tree_map.insert(vec![], Composition::from(vec![
+            vec![Var(0, 0), T("a"), Var(0, 1), T("b")]
+        ]));
+        tree_map.insert(vec![0], Composition::from(vec![
+            vec![Var(1, 0)],
+            vec![T("c")]
+        ]));
+        tree_map.insert(vec![1, 0], Composition::from(vec![
+            vec![T("d")]
+        ]));
+
+        let mut identified_tree_map = BTreeMap::new();
+        identified_tree_map.insert(vec![], Composition::from(vec![
+            vec![Var(0, 0), T((vec![], 1)), Var(0, 1), T((vec![], 3))]
+        ]));
+        identified_tree_map.insert(vec![0], Composition::from(vec![
+            vec![Var(1, 0)],
+            vec![T((vec![0], 1))]
+        ]));
+        identified_tree_map.insert(vec![1, 0], Composition::from(vec![
+            vec![T((vec![1, 0], 0))]
+        ]));
+
+        let mut terminal_map = BTreeMap::new();
+        terminal_map.insert((vec![], 1), "a");
+        terminal_map.insert((vec![], 3), "b");
+        terminal_map.insert((vec![0], 1), "c");
+        terminal_map.insert((vec![1, 0], 0), "d");
+
+        assert_eq!((identified_tree_map, terminal_map), identify_terminals(&tree_map));
+    }
+}

--- a/src/tree_stack_automaton/from_pmcfg.rs
+++ b/src/tree_stack_automaton/from_pmcfg.rs
@@ -259,8 +259,8 @@ pub mod tests {
         let mut tree_map = BTreeMap::new();
         tree_map.insert(vec![], PosState::Initial);
         tree_map.insert(vec![0], PosState::Position('a', 0, 0));
-        tree_map.insert(vec![0,0], PosState::Position('b', 0, 0));
-        tree_map.insert(vec![0,2], PosState::Position('c', 0, 0));
+        tree_map.insert(vec![0, 0], PosState::Position('b', 0, 0));
+        tree_map.insert(vec![0, 2], PosState::Position('c', 0, 0));
         tree_map.insert(vec![2], PosState::Position('d', 0, 0));
 
         let mut abstract_syntax_tree = BTreeMap::new();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
-pub mod parsing;
 pub mod agenda;
-pub mod push_down;
 pub mod integerisable;
+pub mod parsing;
+pub mod push_down;
+pub mod tree;

--- a/src/util/tree.rs
+++ b/src/util/tree.rs
@@ -1,0 +1,50 @@
+use std::collections::BTreeMap;
+use std::collections::btree_map::{IntoIter, Iter};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Eq)]
+pub struct GornTree<V>(BTreeMap<Vec<usize>, V>);
+
+impl<V> GornTree<V> {
+    pub fn new() -> GornTree<V> {
+        GornTree(BTreeMap::new())
+    }
+}
+
+impl<V> Deref for GornTree<V> {
+    type Target = BTreeMap<Vec<usize>, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> DerefMut for GornTree<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<V> IntoIterator for GornTree<V> {
+    type Item = (Vec<usize>, V);
+    type IntoIter = IntoIter<Vec<usize>, V>;
+
+    fn into_iter(self) -> IntoIter<Vec<usize>, V> {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, V> IntoIterator for &'a GornTree<V> {
+    type Item = (&'a Vec<usize>, &'a V);
+    type IntoIter = Iter<'a, Vec<usize>, V>;
+
+    fn into_iter(self) -> Iter<'a, Vec<usize>, V> {
+        (&self.0).into_iter()
+    }
+}
+
+impl<V: PartialEq> PartialEq for GornTree<V> {
+    fn eq(&self, other: &GornTree<V>) -> bool {
+        self.0.eq(&other.0)
+    }
+}


### PR DESCRIPTION
This function takes a tree of `PMCFGRule`s and creates a corresponding string in the NEGRA format, utilising `to_term()`, `identify_terminals()` and `evaluate()` as subroutines.
Because said functions needed to be adapted to work with `to_negra()`, these changes are also contained in this pull request, along with code readability tweaks.