### PR TITLE
"minor" formatting and fixing bugs in the code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rustomata"
 version = "0.1.0"
 authors = ["Tobias Denkinger <tobias.denkinger@tu-dresden.de>"]
 autobins = false
+version = "2018"
 
 [workspace]
 members = ["unique-heap", "search", "vecmultimap"]

--- a/search/src/agenda/beam_heap.rs
+++ b/search/src/agenda/beam_heap.rs
@@ -1,4 +1,4 @@
-use std::collections::{BinaryHeap, binary_heap::IntoIter};
+use std::collections::{binary_heap::IntoIter, BinaryHeap};
 use std::ops::Mul;
 
 use super::weighted::WeightedItem;
@@ -8,28 +8,30 @@ use super::weighted::WeightedItem;
 /// factor.
 pub struct BeamHeap<I, W>
 where
-    W: Ord
+    W: Ord,
 {
     heap: BinaryHeap<WeightedItem<I, W>>,
-    beta: W
+    beta: W,
 }
 
 impl<I, W> BeamHeap<I, W>
 where
-    W: Ord
+    W: Ord,
 {
     pub fn new(beta: W) -> Self {
         BeamHeap {
             heap: BinaryHeap::new(),
-            beta
+            beta,
         }
     }
 
     pub fn push(&mut self, element: I, priority: W) -> bool
     where
-        W: Clone + Mul<Output=W>
+        W: Clone + Mul<Output = W>,
     {
-        if self.heap.is_empty() || priority >= self.heap.peek().unwrap().1.clone() * self.beta.clone() {
+        if self.heap.is_empty()
+            || priority >= self.heap.peek().unwrap().1.clone() * self.beta.clone()
+        {
             self.heap.push(WeightedItem(element, priority));
             true
         } else {
@@ -58,13 +60,14 @@ pub mod weighted {
     use crate::agenda::weighted::Weighted;
     use std::ops::Mul;
     pub struct BeamHeap<I: Weighted>(super::BeamHeap<I, I::Weight>)
-        where I::Weight: Ord;
+    where
+        I::Weight: Ord;
 
     /// An adapter for `super::BeamHeap` that uses priorities of items given by
     /// the implementation of `Weighted`.
     impl<I: Weighted> BeamHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         pub fn new(beta: I::Weight) -> Self {
             BeamHeap(super::BeamHeap::new(beta))
@@ -72,7 +75,7 @@ pub mod weighted {
 
         pub fn push(&mut self, element: I) -> bool
         where
-            I::Weight: Clone + Mul<Output=I::Weight>
+            I::Weight: Clone + Mul<Output = I::Weight>,
         {
             let priority = element.get_weight();
             self.0.push(element, priority)
@@ -95,10 +98,9 @@ pub mod weighted {
         }
     }
 
-
     impl<I: Weighted> IntoIterator for BeamHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         type IntoIter = <super::BeamHeap<I, I::Weight> as IntoIterator>::IntoIter;
         type Item = I;
@@ -111,12 +113,12 @@ pub mod weighted {
 impl<I, W> Clone for BeamHeap<I, W>
 where
     I: Clone,
-    W: Clone + Ord
+    W: Clone + Ord,
 {
     fn clone(&self) -> Self {
         BeamHeap {
             heap: self.heap.clone(),
-            beta: self.beta.clone()
+            beta: self.beta.clone(),
         }
     }
 }
@@ -125,7 +127,7 @@ use super::weighted::RemoveWeight;
 
 impl<I, W> IntoIterator for BeamHeap<I, W>
 where
-    W: Ord
+    W: Ord,
 {
     type IntoIter = RemoveWeight<I, W, IntoIter<WeightedItem<I, W>>>;
     type Item = I;

--- a/search/src/agenda/binary_heap.rs
+++ b/search/src/agenda/binary_heap.rs
@@ -1,7 +1,7 @@
-use std::collections::{BinaryHeap, binary_heap::IntoIter};
+use std::collections::{binary_heap::IntoIter, BinaryHeap};
 
 pub mod weighted {
-    use crate::agenda::weighted::{ Weighted, WeightedItem, RemoveWeight };
+    use crate::agenda::weighted::{RemoveWeight, Weighted, WeightedItem};
     use std::iter::FromIterator;
 
     /// An adapter for `BinaryHeap` that orders elements via the weight
@@ -12,7 +12,7 @@ pub mod weighted {
 
     impl<I: Weighted> BinaryHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         pub fn new() -> Self {
             BinaryHeap(super::BinaryHeap::new())
@@ -42,23 +42,23 @@ pub mod weighted {
 
     impl<I: Weighted> FromIterator<I> for BinaryHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
-        fn from_iter<T: IntoIterator<Item=I>>(iter: T) -> Self {
+        fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
             BinaryHeap(
-                iter.into_iter().map(
-                    |item| {
+                iter.into_iter()
+                    .map(|item| {
                         let priority = item.get_weight();
                         WeightedItem(item, priority)
-                    }
-                ).collect()
+                    })
+                    .collect(),
             )
         }
     }
 
     impl<I: Weighted> IntoIterator for BinaryHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         type IntoIter = RemoveWeight<I, I::Weight, super::IntoIter<WeightedItem<I, I::Weight>>>;
         type Item = I;

--- a/search/src/agenda/limited_heap.rs
+++ b/search/src/agenda/limited_heap.rs
@@ -1,4 +1,4 @@
-use min_max_heap::{MinMaxHeap, IntoIter};
+use min_max_heap::{IntoIter, MinMaxHeap};
 use std::iter::IntoIterator;
 
 use super::weighted::WeightedItem;
@@ -8,10 +8,10 @@ use super::weighted::WeightedItem;
 #[derive(Clone)]
 pub struct LimitedHeap<I, W>
 where
-    W: Ord
+    W: Ord,
 {
     heap: MinMaxHeap<WeightedItem<I, W>>,
-    capacity: usize
+    capacity: usize,
 }
 
 impl<I, W: Ord> LimitedHeap<I, W> {
@@ -54,11 +54,12 @@ pub mod weighted {
     /// An adapter for `super::LimitedHeap` that uses the priority given by the
     /// items' implementation of `Weighted`.
     pub struct LimitedHeap<I: Weighted>(super::LimitedHeap<I, I::Weight>)
-        where I::Weight: Ord;
+    where
+        I::Weight: Ord;
 
     impl<I: Weighted> LimitedHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         pub fn with_capacity(capacity: usize) -> Self {
             LimitedHeap(super::LimitedHeap::with_capacity(capacity))
@@ -86,10 +87,9 @@ pub mod weighted {
         }
     }
 
-
     impl<I: Weighted> IntoIterator for LimitedHeap<I>
     where
-        I::Weight: Ord
+        I::Weight: Ord,
     {
         type IntoIter = <super::LimitedHeap<I, I::Weight> as IntoIterator>::IntoIter;
         type Item = I;
@@ -103,7 +103,7 @@ use super::weighted::RemoveWeight;
 
 impl<I, W> IntoIterator for LimitedHeap<I, W>
 where
-    W: Ord
+    W: Ord,
 {
     type IntoIter = RemoveWeight<I, W, IntoIter<WeightedItem<I, W>>>;
     type Item = I;

--- a/search/src/agenda/mod.rs
+++ b/search/src/agenda/mod.rs
@@ -9,17 +9,16 @@
 //!   interfaces, we separated the elements and priorities. So, the elements
 //!   themselves do not need to implement `Ord`.
 
-
-pub mod weighted;
 pub mod beam_heap;
-pub mod limited_heap;
 pub mod binary_heap;
+pub mod limited_heap;
+pub mod weighted;
 
-pub use self::limited_heap::LimitedHeap;
 pub use self::beam_heap::BeamHeap;
+pub use self::limited_heap::LimitedHeap;
 use self::weighted::Weighted;
 
-use std::{ ops::Mul, collections::VecDeque };
+use std::{collections::VecDeque, ops::Mul};
 
 /// Generic interface to a data structure that can hold some amount of elements
 /// of type `Agenda::Item`.
@@ -30,12 +29,11 @@ pub trait Agenda {
     fn peek(&self) -> Option<&Self::Item>;
     fn len(&self) -> usize;
 
-
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    fn extend<I: IntoIterator<Item=Self::Item>>(&mut self, elements: I) {
+    fn extend<I: IntoIterator<Item = Self::Item>>(&mut self, elements: I) {
         for element in elements {
             self.push(element);
         }
@@ -84,7 +82,7 @@ impl<I> Agenda for VecDeque<I> {
 
 impl<I: Weighted> Agenda for binary_heap::weighted::BinaryHeap<I>
 where
-    I::Weight: Ord
+    I::Weight: Ord,
 {
     type Item = I;
 
@@ -107,7 +105,7 @@ where
 
 impl<I: Weighted> Agenda for beam_heap::weighted::BeamHeap<I>
 where
-    I::Weight: Ord + Mul<Output=I::Weight> + Clone
+    I::Weight: Ord + Mul<Output = I::Weight> + Clone,
 {
     type Item = I;
 
@@ -130,7 +128,7 @@ where
 
 impl<I: Weighted> Agenda for limited_heap::weighted::LimitedHeap<I>
 where
-    I::Weight: Ord
+    I::Weight: Ord,
 {
     type Item = I;
 

--- a/search/src/agenda/weighted.rs
+++ b/search/src/agenda/weighted.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-
 /// A trait that gives an interface for a weight assignment.
 pub trait Weighted {
     type Weight;
@@ -14,7 +13,6 @@ impl Weighted for usize {
         *self
     }
 }
-
 
 /// A `WeightedItem` implements the `PartialEq`, `PartialOrd`, `Eq` and `Ord`
 /// traits only with respect to the weight type `W`.
@@ -43,7 +41,7 @@ impl<I, W: Ord> Ord for WeightedItem<I, W> {
 
 impl<I, W> Weighted for WeightedItem<I, W>
 where
-    W: Clone
+    W: Clone,
 {
     type Weight = W;
     fn get_weight(&self) -> Self::Weight {
@@ -53,12 +51,14 @@ where
 
 /// An adapter for `Iterator` that removes the weight type `W` from
 /// `WeightedItem` and just yields the item type `I`.
-pub struct RemoveWeight<I, W, II>(II) where II: Iterator<Item=WeightedItem<I, W>>;
+pub struct RemoveWeight<I, W, II>(II)
+where
+    II: Iterator<Item = WeightedItem<I, W>>;
 
 impl<I, W, Iter, IntoIter> From<IntoIter> for RemoveWeight<I, W, Iter>
 where
-    IntoIter: IntoIterator<Item=WeightedItem<I, W>,IntoIter=Iter>,
-    Iter: Iterator<Item=WeightedItem<I, W>>
+    IntoIter: IntoIterator<Item = WeightedItem<I, W>, IntoIter = Iter>,
+    Iter: Iterator<Item = WeightedItem<I, W>>,
 {
     fn from(ii: IntoIter) -> Self {
         RemoveWeight(ii.into_iter())
@@ -67,7 +67,7 @@ where
 
 impl<I, W, II> Iterator for RemoveWeight<I, W, II>
 where
-    II: Iterator<Item=WeightedItem<I, W>>
+    II: Iterator<Item = WeightedItem<I, W>>,
 {
     type Item = I;
     fn next(&mut self) -> Option<Self::Item> {

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -8,17 +8,15 @@ pub mod search;
 pub use crate::agenda::{Agenda, BeamHeap, LimitedHeap};
 pub use crate::search::Search;
 
-
 #[cfg(test)]
 mod tests {
-    use rand::{SeedableRng, rngs::SmallRng, Rng};
+    use rand::{rngs::SmallRng, Rng, SeedableRng};
 
-    use super::LimitedHeap;
+    use super::test::{black_box, Bencher};
     use super::BeamHeap;
-    use std::collections::BinaryHeap;
-    use super::test::{Bencher, black_box};
+    use super::LimitedHeap;
     use min_max_heap::MinMaxHeap;
-
+    use std::collections::BinaryHeap;
 
     const CAP: usize = 500;
     const ELM: usize = 1000;
@@ -33,9 +31,7 @@ mod tests {
         b.iter(|| {
             q.clear();
             for element in elements.iter() {
-                black_box(
-                    q.push(*element, *element)
-                );
+                black_box(q.push(*element, *element));
             }
         });
     }
@@ -49,9 +45,7 @@ mod tests {
         b.iter(|| {
             q.clear();
             for element in elements.iter() {
-                black_box(
-                    q.push(*element)
-                );
+                black_box(q.push(*element));
             }
         });
     }
@@ -65,9 +59,7 @@ mod tests {
         b.iter(|| {
             q.clear();
             for element in elements.iter() {
-                black_box(
-                    q.push(*element)
-                );
+                black_box(q.push(*element));
             }
         });
     }
@@ -81,9 +73,7 @@ mod tests {
         b.iter(|| {
             q.clear();
             for element in elements.iter() {
-                black_box(
-                    q.push(*element, *element)
-                );
+                black_box(q.push(*element, *element));
             }
         });
     }

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -1,8 +1,8 @@
 //! This module provides the `Search` type, an `Iterator` over nodes in a graph
 //! that is explored as an object of this type iterates.
 
-use crate::agenda::{ Agenda, binary_heap::weighted::BinaryHeap, weighted::Weighted };
-use std::collections::{VecDeque};
+use crate::agenda::{binary_heap::weighted::BinaryHeap, weighted::Weighted, Agenda};
+use std::collections::VecDeque;
 
 /// An `Iterator` exploring a graph with current frontier nodes in `agenda`
 /// and a successor relation.
@@ -10,24 +10,21 @@ pub struct Search<A, S, II>
 where
     A: Agenda,
     S: FnMut(&A::Item) -> II,
-    II: IntoIterator<Item=A::Item>
+    II: IntoIterator<Item = A::Item>,
 {
     agenda: A,
-    successors: S
+    successors: S,
 }
 
 impl<A, S, II> Search<A, S, II>
 where
     A: Agenda,
     S: FnMut(&A::Item) -> II,
-    II: IntoIterator<Item=A::Item>
+    II: IntoIterator<Item = A::Item>,
 {
     /// Constructs a `Search` with a given `Agenda` object.
     pub fn with_agenda(agenda: A, successors: S) -> Self {
-        Search {
-            agenda,
-            successors
-        }
+        Search { agenda, successors }
     }
 }
 
@@ -35,8 +32,8 @@ impl<A, S, II> Search<A, S, II>
 where
     A: Agenda,
     S: FnMut(&A::Item) -> II,
-    II: IntoIterator<Item=A::Item>,
-    A::Item: Ord
+    II: IntoIterator<Item = A::Item>,
+    A::Item: Ord,
 {
     /// Transforms the `Search` into a `unique::Search`. This will enumerate
     /// only unique nodes (respecting the implementation of `Ord`) in a graph.
@@ -48,10 +45,10 @@ where
 impl<I, S, II> Search<Vec<I>, S, II>
 where
     S: FnMut(&I) -> II,
-    II: IntoIterator<Item=I>
+    II: IntoIterator<Item = I>,
 {
     /// Performs a depth-first search.
-    pub fn dfs<II2: IntoIterator<Item=I>>(initials: II2, successors: S) -> Self {
+    pub fn dfs<II2: IntoIterator<Item = I>>(initials: II2, successors: S) -> Self {
         Search::with_agenda(initials.into_iter().collect::<Vec<_>>(), successors)
     }
 }
@@ -59,10 +56,10 @@ where
 impl<I, S, II> Search<VecDeque<I>, S, II>
 where
     S: FnMut(&I) -> II,
-    II: IntoIterator<Item=I>
+    II: IntoIterator<Item = I>,
 {
     /// Performs a breadth-first search.
-    pub fn bfs<II2: IntoIterator<Item=I>>(initials: II2, successors: S) -> Self {
+    pub fn bfs<II2: IntoIterator<Item = I>>(initials: II2, successors: S) -> Self {
         Search::with_agenda(initials.into_iter().collect::<VecDeque<_>>(), successors)
     }
 }
@@ -71,10 +68,10 @@ impl<I: Weighted, S, II> Search<BinaryHeap<I>, S, II>
 where
     I::Weight: Ord,
     S: FnMut(&I) -> II,
-    II: IntoIterator<Item=I>
+    II: IntoIterator<Item = I>,
 {
     /// Performs a Dijkstra search.
-    pub fn weighted<II2: IntoIterator<Item=I>>(initials: II2, successors: S) -> Self {
+    pub fn weighted<II2: IntoIterator<Item = I>>(initials: II2, successors: S) -> Self {
         Search::with_agenda(initials.into_iter().collect::<BinaryHeap<_>>(), successors)
     }
 }
@@ -83,7 +80,7 @@ impl<A, S, II> Iterator for Search<A, S, II>
 where
     A: Agenda,
     S: FnMut(&A::Item) -> II,
-    II: IntoIterator<Item=A::Item>
+    II: IntoIterator<Item = A::Item>,
 {
     type Item = A::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -97,51 +94,58 @@ where
 }
 
 pub mod unique {
-    use std::collections::BTreeSet;
     use crate::agenda::Agenda;
+    use std::collections::BTreeSet;
 
     /// This is an adapter for `super::Search` that filters nodes that already
     /// occured during the iteration.
-    pub struct Search<A, S, II> 
+    pub struct Search<A, S, II>
     where
         A: Agenda,
         S: FnMut(&A::Item) -> II,
-        II: IntoIterator<Item=A::Item>
+        II: IntoIterator<Item = A::Item>,
     {
         search: super::Search<A, S, II>,
-        elements: BTreeSet<A::Item>
+        elements: BTreeSet<A::Item>,
     }
 
     impl<A, S, II> Search<A, S, II>
     where
         A: Agenda,
         S: FnMut(&A::Item) -> II,
-        II: IntoIterator<Item=A::Item>,
-        A::Item: Ord
+        II: IntoIterator<Item = A::Item>,
+        A::Item: Ord,
     {
         /// Creates a unique `Search` from a `super::Search`.
         pub fn from_search(search: super::Search<A, S, II>) -> Self {
-            Search{
+            Search {
                 search,
-                elements: BTreeSet::new()
+                elements: BTreeSet::new(),
             }
         }
     }
-    
+
     impl<A, S, II> Iterator for Search<A, S, II>
     where
         A: Agenda,
         S: FnMut(&A::Item) -> II,
-        II: IntoIterator<Item=A::Item>,
-        A::Item: Ord + Clone
+        II: IntoIterator<Item = A::Item>,
+        A::Item: Ord + Clone,
     {
         type Item = A::Item;
         fn next(&mut self) -> Option<Self::Item> {
-            let &mut Search{ref mut search, ref mut elements} = self;
-            
+            let &mut Search {
+                ref mut search,
+                ref mut elements,
+            } = self;
+
             if let Some(item) = search.agenda.pop() {
                 if elements.insert(item.clone()) {
-                    search.agenda.extend((search.successors)(&item).into_iter().filter(|i| !elements.contains(i)));
+                    search.agenda.extend(
+                        (search.successors)(&item)
+                            .into_iter()
+                            .filter(|i| !elements.contains(i)),
+                    );
                     Some(item)
                 } else {
                     None

--- a/src/approximation/equivalence_classes.rs
+++ b/src/approximation/equivalence_classes.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::iter::FromIterator;
 use std::str::FromStr;
 
-use util::parsing::*;
+use crate::util::parsing::*;
 
 /// Structure containing the elements of type `A` in an equivalence class of type `B`
 #[derive(Debug, Eq, PartialEq)]

--- a/src/approximation/equivalence_classes.rs
+++ b/src/approximation/equivalence_classes.rs
@@ -1,6 +1,6 @@
-use nom::{IResult, is_space};
-use std::collections::{HashMap, HashSet};
+use nom::{is_space, IResult};
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::FromIterator;
@@ -191,21 +191,12 @@ where
 {
     do_parse!(
         input,
-        label: parse_token >>
-            take_while!(is_space) >>
-            set: alt!(
-                do_parse!(
-                    tag!("*") >> (None)
-                )
-                    |
-                do_parse!(
-                    the_set: parse_set >> (Some(the_set))
-                )
-            ) >>
-            (EquivalenceClass {
-                label,
-                set,
-            })
+        label: parse_token
+            >> take_while!(is_space)
+            >> set: alt!(
+                do_parse!(tag!("*") >> (None)) | do_parse!(the_set: parse_set >> (Some(the_set)))
+            )
+            >> (EquivalenceClass { label, set })
     )
 }
 
@@ -216,8 +207,7 @@ where
 {
     do_parse!(
         input,
-        output: apply!(parse_vec, parse_token, "[", "]", ",") >>
-        (HashSet::from_iter(output))
+        output: apply!(parse_vec, parse_token, "[", "]", ",") >> (HashSet::from_iter(output))
     )
 }
 
@@ -231,17 +221,17 @@ mod tests {
             (
                 "0 [0, 1]xyz",
                 "xyz",
-                EquivalenceClass::from((0, Some(vec![0, 1])))
+                EquivalenceClass::from((0, Some(vec![0, 1]))),
             ),
             (
                 "0  [1, 0]1 [2, 3]",
                 "1 [2, 3]",
-                EquivalenceClass::from((0, Some(vec![0, 1])))
+                EquivalenceClass::from((0, Some(vec![0, 1]))),
             ),
             (
                 "0  [0, 1, 1]\nxyz",
                 "\nxyz",
-                EquivalenceClass::from((0, Some(vec![0, 1])))
+                EquivalenceClass::from((0, Some(vec![0, 1]))),
             ),
             ("0 *xyz", "xyz", EquivalenceClass::from((0, None))),
         ];
@@ -260,13 +250,10 @@ mod tests {
 
         for incomplete_input in incomplete_inputs {
             match parse_class::<u8, u8>(incomplete_input.as_bytes()) {
-                IResult::Done(_, _) |
-                IResult::Error(_) => {
-                    panic!(
-                        "The input was not handled as incomplete: \'{}\'",
-                        incomplete_input
-                    )
-                }
+                IResult::Done(_, _) | IResult::Error(_) => panic!(
+                    "The input was not handled as incomplete: \'{}\'",
+                    incomplete_input
+                ),
                 IResult::Incomplete(_) => (),
             }
         }
@@ -278,8 +265,7 @@ mod tests {
 
         for illegal_input in illegal_inputs {
             match parse_class::<u8, u8>(illegal_input.as_bytes()) {
-                IResult::Done(_, _) |
-                IResult::Incomplete(_) => {
+                IResult::Done(_, _) | IResult::Incomplete(_) => {
                     panic!("Was able to parse the illegal input \'{}\'", illegal_input)
                 }
                 IResult::Error(_) => (),
@@ -338,7 +324,7 @@ mod tests {
                     EquivalenceClass::from((0, Some(vec![0, 1]))),
                     EquivalenceClass::from((1, Some(vec![2, 3]))),
                     EquivalenceClass::from((2, None)),
-                ])
+                ]),
             ),
             (
                 " 0 [0, 1]\n 1 [2, 3]  \n2 *  ",
@@ -346,7 +332,7 @@ mod tests {
                     EquivalenceClass::from((0, Some(vec![0, 1]))),
                     EquivalenceClass::from((1, Some(vec![2, 3]))),
                     EquivalenceClass::from((2, None)),
-                ])
+                ]),
             ),
         ];
 
@@ -371,13 +357,10 @@ mod tests {
 
         for illegal_input in illegal_inputs {
             match EquivalenceRelation::<u8, u8>::from_str(illegal_input) {
-                Ok(parsed) => {
-                    panic!(
-                        "Was able to parse the illegal input \'{}\' as \'{:?}\'",
-                        illegal_input,
-                        parsed
-                    )
-                }
+                Ok(parsed) => panic!(
+                    "Was able to parse the illegal input \'{}\' as \'{:?}\'",
+                    illegal_input, parsed
+                ),
                 Err(_) => (),
             }
         }

--- a/src/approximation/mod.rs
+++ b/src/approximation/mod.rs
@@ -2,9 +2,9 @@ use num_traits::One;
 use std::collections::{BinaryHeap, BTreeMap};
 use std::ops::MulAssign;
 
-use recognisable::{Instruction, Transition};
-use recognisable::automaton::Automaton;
-use util::push_down::Pushdown;
+use crate::recognisable::{Instruction, Transition};
+use crate::recognisable::automaton::Automaton;
+use crate::util::push_down::Pushdown;
 
 pub mod equivalence_classes;
 pub mod relabel;
@@ -27,10 +27,10 @@ where
 
     fn approximate_storage(
         &self,
-        <Self::I1 as Instruction>::Storage,
+        _: <Self::I1 as Instruction>::Storage,
     ) -> <Self::I2 as Instruction>::Storage;
 
-    fn approximate_instruction(&self, &Self::I1) -> Self::I2;
+    fn approximate_instruction(&self, _: &Self::I1) -> Self::I2;
 
     fn approximate_automaton(
         self,

--- a/src/approximation/mod.rs
+++ b/src/approximation/mod.rs
@@ -1,9 +1,9 @@
 use num_traits::One;
-use std::collections::{BinaryHeap, BTreeMap};
+use std::collections::{BTreeMap, BinaryHeap};
 use std::ops::MulAssign;
 
-use crate::recognisable::{Instruction, Transition};
 use crate::recognisable::automaton::Automaton;
+use crate::recognisable::{Instruction, Transition};
 use crate::util::push_down::Pushdown;
 
 pub mod equivalence_classes;
@@ -116,7 +116,8 @@ where
         run2: Pushdown<Transition<Strategy::I2, T, W>>,
     ) -> BinaryHeap<Pushdown<Transition<Strategy::I1, T, W>>> {
         let f = |h: BinaryHeap<Pushdown<_>>, ts1: Vec<_>| {
-            let new_runs: Vec<Pushdown<_>> = h.into_iter()
+            let new_runs: Vec<Pushdown<_>> = h
+                .into_iter()
                 .flat_map(|run: Pushdown<_>| -> Vec<Pushdown<_>> {
                     let push_transition = |t1: &Transition<_, _, _>| run.clone().push(t1.clone());
                     ts1.iter().map(push_transition).collect()

--- a/src/approximation/relabel.rs
+++ b/src/approximation/relabel.rs
@@ -2,8 +2,8 @@ use num_traits::Zero;
 use std::hash::Hash;
 use std::ops::{AddAssign, MulAssign};
 
-use approximation::*;
-use automata::push_down_automaton::*;
+use crate::approximation::*;
+use crate::automata::push_down_automaton::*;
 
 /// `ApproximationStrategy` that uses the `Relabel` trait to relabel internal values via an `EquivalenceClass`
 pub struct RlbElement<'a, A1, A2>

--- a/src/approximation/relabel.rs
+++ b/src/approximation/relabel.rs
@@ -21,29 +21,29 @@ impl<'a, A1, A2> RlbElement<'a, A1, A2> {
 }
 
 impl<'a, A1, A2, T, W> ApproximationStrategy<T, W> for RlbElement<'a, A1, A2>
-    where A1: Clone + Hash + Ord,
-          A2: Clone + Hash + Ord,
-          T: Clone + Eq + Hash + Ord,
-          W: AddAssign + Copy + MulAssign + One + Ord + Zero,
+where
+    A1: Clone + Hash + Ord,
+    A2: Clone + Hash + Ord,
+    T: Clone + Eq + Hash + Ord,
+    W: AddAssign + Copy + MulAssign + One + Ord + Zero,
 {
     type I1 = PushDownInstruction<A1>;
     type I2 = PushDownInstruction<A2>;
     type A1 = PushDownAutomaton<A1, T, W>;
     type A2 = PushDownAutomaton<A2, T, W>;
 
-    fn approximate_storage(&self, pd: PushDown<A1>)-> PushDown<A2> {
+    fn approximate_storage(&self, pd: PushDown<A1>) -> PushDown<A2> {
         pd.map(&self.mapping)
     }
 
-    fn approximate_instruction(&self, instr: &PushDownInstruction<A1>)
-                               -> PushDownInstruction<A2>
-    {
+    fn approximate_instruction(&self, instr: &PushDownInstruction<A1>) -> PushDownInstruction<A2> {
         match *instr {
-            PushDownInstruction::Replace { ref current_val, ref new_val } => {
-                PushDownInstruction::Replace {
-                    current_val: current_val.iter().map(self.mapping).collect(),
-                    new_val: new_val.iter().map(self.mapping).collect(),
-                }
+            PushDownInstruction::Replace {
+                ref current_val,
+                ref new_val,
+            } => PushDownInstruction::Replace {
+                current_val: current_val.iter().map(self.mapping).collect(),
+                new_val: new_val.iter().map(self.mapping).collect(),
             },
         }
     }
@@ -51,8 +51,8 @@ impl<'a, A1, A2, T, W> ApproximationStrategy<T, W> for RlbElement<'a, A1, A2>
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::equivalence_classes::EquivalenceRelation;
+    use super::*;
     use std::str::FromStr;
 
     #[test]
@@ -84,7 +84,9 @@ mod tests {
 
         assert_eq!(
             control_pushdown,
-            <RlbElement<_, _> as ApproximationStrategy<char, u8>>::approximate_storage(&rlb, pushdown)
+            <RlbElement<_, _> as ApproximationStrategy<char, u8>>::approximate_storage(
+                &rlb, pushdown
+            )
         );
     }
 

--- a/src/approximation/tts.rs
+++ b/src/approximation/tts.rs
@@ -3,9 +3,9 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::ops::{AddAssign, MulAssign};
 
-use approximation::*;
-use automata::push_down_automaton::*;
-use automata::tree_stack_automaton::*;
+use crate::approximation::*;
+use crate::automata::push_down_automaton::*;
+use crate::automata::tree_stack_automaton::*;
 
 /// `ApproximationStrategy` that approximates a `TreeStackAutomaton` into a `PushDownAutomaton`
 #[derive(Clone, Debug)]

--- a/src/approximation/tts.rs
+++ b/src/approximation/tts.rs
@@ -15,7 +15,9 @@ pub struct TTSElement<A> {
 
 impl<A> TTSElement<A> {
     pub fn new() -> Self {
-        TTSElement { _dummy: PhantomData }
+        TTSElement {
+            _dummy: PhantomData,
+        }
     }
 }
 
@@ -23,12 +25,7 @@ impl<A, T, W> ApproximationStrategy<T, W> for TTSElement<A>
 where
     A: Clone + Hash + Ord,
     T: Clone + Eq + Hash + Ord,
-    W: AddAssign
-        + Copy
-        + MulAssign
-        + One
-        + Ord
-        + Zero,
+    W: AddAssign + Copy + MulAssign + One + Ord + Zero,
 {
     type I1 = TreeStackInstruction<A>;
     type I2 = PushDownInstruction<A>;
@@ -54,27 +51,23 @@ where
                 ref current_val,
                 ref new_val,
                 ..
-            } |
-            TreeStackInstruction::Push {
+            }
+            | TreeStackInstruction::Push {
                 ref current_val,
                 ref new_val,
                 ..
-            } => {
-                PushDownInstruction::Replace {
-                    current_val: vec![current_val.clone()],
-                    new_val: vec![current_val.clone(), new_val.clone()],
-                }
-            }
+            } => PushDownInstruction::Replace {
+                current_val: vec![current_val.clone()],
+                new_val: vec![current_val.clone(), new_val.clone()],
+            },
             TreeStackInstruction::Down {
                 ref current_val,
                 ref old_val,
                 ref new_val,
-            } => {
-                PushDownInstruction::Replace {
-                    current_val: vec![current_val.clone(), old_val.clone()],
-                    new_val: vec![new_val.clone()],
-                }
-            }
+            } => PushDownInstruction::Replace {
+                current_val: vec![current_val.clone(), old_val.clone()],
+                new_val: vec![new_val.clone()],
+            },
         }
     }
 }
@@ -116,7 +109,7 @@ mod tests {
                 PushDownInstruction::Replace {
                     current_val: vec!['@'],
                     new_val: vec!['@', '3'],
-                }
+                },
             ),
             (
                 TreeStackInstruction::Down {
@@ -127,7 +120,7 @@ mod tests {
                 PushDownInstruction::Replace {
                     current_val: vec!['4', '2'],
                     new_val: vec!['3'],
-                }
+                },
             ),
             (
                 TreeStackInstruction::Push {
@@ -138,7 +131,7 @@ mod tests {
                 PushDownInstruction::Replace {
                     current_val: vec!['2'],
                     new_val: vec!['2', '3'],
-                }
+                },
             ),
         ];
 

--- a/src/automata/finite_state_automaton/from_str.rs
+++ b/src/automata/finite_state_automaton/from_str.rs
@@ -1,12 +1,12 @@
+use crate::automata::finite_state_automaton::{FiniteStateAutomaton, FiniteStateInstruction};
+use crate::recognisable::Transition;
+use crate::util::parsing::{parse_finals, parse_initial};
 use nom::IResult;
 use num_traits::One;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::vec::Vec;
 use std::str::FromStr;
-use crate::recognisable::Transition;
-use crate::automata::finite_state_automaton::{FiniteStateAutomaton, FiniteStateInstruction};
-use crate::util::parsing::{parse_finals, parse_initial};
+use std::vec::Vec;
 
 impl<Q, T, W> FromStr for FiniteStateAutomaton<Q, T, W>
 where
@@ -36,7 +36,7 @@ where
                 }
             } else if l.trim_start().starts_with("final:") {
                 match parse_finals(l.trim_start().as_bytes()) {
-                     IResult::Done(_, result) => {
+                    IResult::Done(_, result) => {
                         fin = result;
                     }
                     _ => return Err(format!("Malformed final declaration: {}", l)),
@@ -47,14 +47,12 @@ where
         }
 
         match (init, fin) {
-            (None, ref r) if r.len() == 0 =>
-                Err(format!("No initial state and no final states found.")),
-            (None, _) =>
-                Err(format!("No initial state found.")),
-            (Some(_), ref r) if r.len() == 0 =>
-                Err(format!("No final states found.")),
-            (Some(i), r) =>
-                Ok(FiniteStateAutomaton::new(transitions, i, r)),
+            (None, ref r) if r.len() == 0 => {
+                Err(format!("No initial state and no final states found."))
+            }
+            (None, _) => Err(format!("No initial state found.")),
+            (Some(_), ref r) if r.len() == 0 => Err(format!("No final states found.")),
+            (Some(i), r) => Ok(FiniteStateAutomaton::new(transitions, i, r)),
         }
     }
 }
@@ -70,15 +68,11 @@ where
         let e: String = "Malformed state.".to_string();
         if v.len() == 3 {
             match v[1] {
-                "->" | "→" => {
-                    Ok(FiniteStateInstruction {
-                        source_state: v[0].parse().map_err(|_| e.clone())?,
-                        target_state: v[2].parse().map_err(|_| e.clone())?,
-                    })
-                },
-                _ => {
-                    Err(format!("FiniteStateInstruction malformed: {}", s))
-                },
+                "->" | "→" => Ok(FiniteStateInstruction {
+                    source_state: v[0].parse().map_err(|_| e.clone())?,
+                    target_state: v[2].parse().map_err(|_| e.clone())?,
+                }),
+                _ => Err(format!("FiniteStateInstruction malformed: {}", s)),
             }
         } else {
             Err(format!("FiniteStateInstruction malformed: {}", s))

--- a/src/automata/finite_state_automaton/from_str.rs
+++ b/src/automata/finite_state_automaton/from_str.rs
@@ -4,9 +4,9 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::vec::Vec;
 use std::str::FromStr;
-use recognisable::Transition;
-use automata::finite_state_automaton::{FiniteStateAutomaton, FiniteStateInstruction};
-use util::parsing::{parse_finals, parse_initial};
+use crate::recognisable::Transition;
+use crate::automata::finite_state_automaton::{FiniteStateAutomaton, FiniteStateInstruction};
+use crate::util::parsing::{parse_finals, parse_initial};
 
 impl<Q, T, W> FromStr for FiniteStateAutomaton<Q, T, W>
 where

--- a/src/automata/finite_state_automaton/mod.rs
+++ b/src/automata/finite_state_automaton/mod.rs
@@ -2,14 +2,14 @@ extern crate bit_set;
 
 use integeriser::{HashIntegeriser, Integeriser};
 use num_traits::One;
-use recognisable::{automaton::Automaton,Configuration, Instruction, Item, Transition};
+use crate::recognisable::{automaton::Automaton,Configuration, Instruction, Item, Transition};
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::MulAssign;
 use std::rc::Rc;
-use util::integerisable::{Integerisable1, Integerisable2};
-use util::push_down::Pushdown;
+use crate::util::integerisable::{Integerisable1, Integerisable2};
+use crate::util::push_down::Pushdown;
 
 use self::bit_set::BitSet;
 

--- a/src/automata/finite_state_automaton/mod.rs
+++ b/src/automata/finite_state_automaton/mod.rs
@@ -1,22 +1,21 @@
 extern crate bit_set;
 
+use crate::recognisable::{automaton::Automaton, Configuration, Instruction, Item, Transition};
+use crate::util::integerisable::{Integerisable1, Integerisable2};
+use crate::util::push_down::Pushdown;
 use integeriser::{HashIntegeriser, Integeriser};
 use num_traits::One;
-use crate::recognisable::{automaton::Automaton,Configuration, Instruction, Item, Transition};
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::MulAssign;
 use std::rc::Rc;
-use crate::util::integerisable::{Integerisable1, Integerisable2};
-use crate::util::push_down::Pushdown;
 
 use self::bit_set::BitSet;
 
 mod from_str;
 
-type TransitionMap<Q, T, W>
-    = HashMap<Q, BinaryHeap<Transition<FiniteStateInstruction<Q>, T, W>>>;
+type TransitionMap<Q, T, W> = HashMap<Q, BinaryHeap<Transition<FiniteStateInstruction<Q>, T, W>>>;
 
 #[derive(Clone, Debug)]
 pub struct FiniteStateAutomaton<Q, T, W>
@@ -89,9 +88,9 @@ where
         let fin = finals.into_iter().map(|q| q_inter.integerise(q)).collect();
         let mut transition_map: TransitionMap<usize, usize, W> = HashMap::new();
 
-        for trans in transitions.into_iter().map(|t| {
-            t.integerise(&mut t_inter, &mut q_inter)
-        })
+        for trans in transitions
+            .into_iter()
+            .map(|t| t.integerise(&mut t_inter, &mut q_inter))
         {
             transition_map
                 .entry(trans.instruction.source_state)
@@ -117,7 +116,6 @@ where
             })
         }))
     }
-
 }
 
 impl<Q, T, W> Automaton<T, W> for FiniteStateAutomaton<Q, T, W>
@@ -145,7 +143,10 @@ where
     }
 
     fn initial(&self) -> Q {
-        self.q_integeriser.find_value(self.initial_state).unwrap().clone()
+        self.q_integeriser
+            .find_value(self.initial_state)
+            .unwrap()
+            .clone()
     }
 
     fn item_map(
@@ -159,7 +160,7 @@ where
                     ref storage,
                     ref weight,
                 },
-                ref pd
+                ref pd,
             ) => {
                 let pd_vec: Vec<_> = pd.clone().into();
                 let pd_unint: Vec<_> = pd_vec
@@ -170,7 +171,8 @@ where
                     .collect();
                 Item(
                     Configuration {
-                        word: word.iter()
+                        word: word
+                            .iter()
                             .map(|t| self.t_integeriser.find_value(*t).unwrap().clone())
                             .collect(),
                         storage: self.q_integeriser.find_value(*storage).unwrap().clone(),
@@ -212,7 +214,6 @@ where
     }
 }
 
-
 impl<Q, T, W> Display for FiniteStateAutomaton<Q, T, W>
 where
     Q: Clone + Display + Hash + Ord,
@@ -225,7 +226,7 @@ where
 
         buffer.push_str("final: [");
         let mut first = true;
-        for i in 0 .. self.final_states.len() {
+        for i in 0..self.final_states.len() {
             if self.final_states.contains(i) {
                 if first {
                     buffer.push_str(", ");

--- a/src/automata/push_down_automaton/from_cfg.rs
+++ b/src/automata/push_down_automaton/from_cfg.rs
@@ -8,9 +8,9 @@ use std::ops::{AddAssign, Mul, Div};
 use self::num_traits::{One, Zero};
 use std::str::FromStr;
 
-use recognisable::Transition;
-use grammars::cfg::*;
-use automata::push_down_automaton::{PushDown, PushDownAutomaton, PushDownInstruction};
+use crate::recognisable::Transition;
+use crate::grammars::cfg::*;
+use crate::automata::push_down_automaton::{PushDown, PushDownAutomaton, PushDownInstruction};
 
 /// Symbols of a `PushDown` created by an `CFG`
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]

--- a/src/automata/push_down_automaton/mod.rs
+++ b/src/automata/push_down_automaton/mod.rs
@@ -1,9 +1,9 @@
 extern crate num_traits;
 
+use crate::recognisable::automaton::Automaton;
+use crate::recognisable::{self, Configuration, Instruction, Item, Recognisable, Transition};
 use integeriser::{HashIntegeriser, Integeriser};
 use num_traits::{One, Zero};
-use crate::recognisable::{self, Configuration, Instruction, Item, Recognisable, Transition};
-use crate::recognisable::automaton::Automaton;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -88,12 +88,10 @@ impl<A> PushDownInstruction<A> {
             PushDownInstruction::Replace {
                 ref current_val,
                 ref new_val,
-            } => {
-                PushDownInstruction::Replace {
-                    current_val: map_vec_mut(current_val, f),
-                    new_val: map_vec_mut(new_val, f),
-                }
-            }
+            } => PushDownInstruction::Replace {
+                current_val: map_vec_mut(current_val, f),
+                new_val: map_vec_mut(new_val, f),
+            },
         }
     }
 }
@@ -143,12 +141,14 @@ where
         let init = initial.integerise(&mut a_inter);
         let mut transition_map = HashMap::new();
 
-        for t in transitions.into_iter().map(|t| {
-            t.integerise(&mut t_inter, &mut a_inter)
-        })
+        for t in transitions
+            .into_iter()
+            .map(|t| t.integerise(&mut t_inter, &mut a_inter))
         {
             match t.instruction {
-                PushDownInstruction::Replace { ref current_val, .. } => {
+                PushDownInstruction::Replace {
+                    ref current_val, ..
+                } => {
                     let a = current_val.first().unwrap().clone();
                     *transition_map
                         .entry(a)
@@ -163,12 +163,10 @@ where
             (
                 k,
                 hm.into_iter()
-                    .map(|((w, i), wt)| {
-                        Transition {
-                            word: w,
-                            instruction: i,
-                            weight: wt,
-                        }
+                    .map(|((w, i), wt)| Transition {
+                        word: w,
+                        instruction: i,
+                        weight: wt,
                     })
                     .collect(),
             )
@@ -220,12 +218,7 @@ impl<A, T, W> Automaton<T, W> for PushDownAutomaton<A, T, W>
 where
     A: Ord + PartialEq + Clone + Hash,
     T: Clone + Eq + Hash + Ord,
-    W: AddAssign
-        + Clone
-        + MulAssign
-        + One
-        + Ord
-        + Zero,
+    W: AddAssign + Clone + MulAssign + One + Ord + Zero,
 {
     type Key = usize;
     type I = PushDownInstruction<A>;
@@ -254,12 +247,14 @@ where
         i: &Item<PushDown<usize>, PushDownInstruction<usize>, usize, W>,
     ) -> Item<PushDown<A>, PushDownInstruction<A>, T, W> {
         match *i {
-            Item(Configuration {
-                 ref word,
-                 ref storage,
-                 ref weight,
-             },
-             ref pd) => {
+            Item(
+                Configuration {
+                    ref word,
+                    ref storage,
+                    ref weight,
+                },
+                ref pd,
+            ) => {
                 let pd_vec: Vec<_> = pd.clone().into();
                 let pd_unint: Vec<_> = pd_vec
                     .iter()
@@ -269,7 +264,8 @@ where
                     .collect();
                 Item(
                     Configuration {
-                        word: word.iter()
+                        word: word
+                            .iter()
                             .map(|t| self.t_integeriser.find_value(*t).unwrap().clone())
                             .collect(),
                         storage: Integerisable1::un_integerise(storage, &self.a_integeriser),
@@ -297,7 +293,6 @@ where
         self.transitions.clone()
     }
 
-
     fn initial_int(&self) -> PushDown<usize> {
         self.initial.clone()
     }
@@ -305,22 +300,9 @@ where
 
 impl<A, T, W> Recognisable<T, W> for PushDownAutomaton<A, T, W>
 where
-    A: Ord
-        + PartialEq
-        + Debug
-        + Clone
-        + Hash,
+    A: Ord + PartialEq + Debug + Clone + Hash,
     T: Clone + Debug + Eq + Hash + Ord,
-    W: AddAssign
-        + One
-        + Mul<Output = W>
-        + MulAssign
-        + Clone
-        + Copy
-        + Debug
-        + Eq
-        + Ord
-        + Zero,
+    W: AddAssign + One + Mul<Output = W> + MulAssign + Clone + Copy + Debug + Eq + Ord + Zero,
 {
     type Parse = Item<PushDown<A>, PushDownInstruction<A>, T, W>;
 
@@ -358,14 +340,18 @@ impl<A> PushDown<A> {
     where
         F: Fn(&A) -> B,
     {
-        PushDown { elements: self.elements.iter().map(f).collect() }
+        PushDown {
+            elements: self.elements.iter().map(f).collect(),
+        }
     }
 
     pub fn map_mut<F, B>(&self, f: &mut F) -> PushDown<B>
     where
         F: FnMut(&A) -> B,
     {
-        PushDown { elements: self.elements.iter().map(f).collect() }
+        PushDown {
+            elements: self.elements.iter().map(f).collect(),
+        }
     }
 }
 
@@ -477,13 +463,7 @@ impl<A, T, W> Display for PushDownAutomaton<A, T, W>
 where
     A: Clone + Display + Hash + Ord + PartialEq,
     T: Clone + Debug + Display + Eq + Hash + Ord,
-    W: AddAssign
-        + Clone
-        + Display
-        + MulAssign
-        + One
-        + Ord
-        + Zero,
+    W: AddAssign + Clone + Display + MulAssign + One + Ord + Zero,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut formatted_transitions = String::new();

--- a/src/automata/push_down_automaton/mod.rs
+++ b/src/automata/push_down_automaton/mod.rs
@@ -2,8 +2,8 @@ extern crate num_traits;
 
 use integeriser::{HashIntegeriser, Integeriser};
 use num_traits::{One, Zero};
-use recognisable::{self, Configuration, Instruction, Item, Recognisable, Transition};
-use recognisable::automaton::Automaton;
+use crate::recognisable::{self, Configuration, Instruction, Item, Recognisable, Transition};
+use crate::recognisable::automaton::Automaton;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -13,8 +13,8 @@ use std::rc::Rc;
 use std::slice::Iter;
 use std::vec::Vec;
 
-use util::integerisable::{Integerisable1, Integerisable2};
-use util::push_down::Pushdown;
+use crate::util::integerisable::{Integerisable1, Integerisable2};
+use crate::util::push_down::Pushdown;
 
 mod from_cfg;
 // TODO: mod from_str;

--- a/src/automata/tree_stack_automaton/from_pmcfg.rs
+++ b/src/automata/tree_stack_automaton/from_pmcfg.rs
@@ -1,15 +1,15 @@
 extern crate num_traits;
 
-use std::collections::{BTreeSet, BTreeMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Display, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::vec::Vec;
 
 use self::num_traits::One;
-use crate::grammars::pmcfg::{PMCFG, PMCFGRule, VarT};
-use crate::recognisable::Transition;
 use crate::automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
+use crate::grammars::pmcfg::{PMCFGRule, VarT, PMCFG};
+use crate::recognisable::Transition;
 use crate::util::tree::GornTree;
 
 // types for analysis of derivation trees of PMCFGs
@@ -48,10 +48,11 @@ impl<X: Display> Display for PosState<X> {
 
 // TODO assumes that the PMCFG is monotonic on the visit-order of components
 impl<
-    N: Clone + Ord + PartialEq + Hash,
-    T: Clone + Ord + PartialEq + Hash,
-    W: Clone + Ord + PartialEq + One,
-> From<PMCFG<N, T, W>> for TreeStackAutomaton<PosState<PMCFGRule<N, T, W>>, T, W> {
+        N: Clone + Ord + PartialEq + Hash,
+        T: Clone + Ord + PartialEq + Hash,
+        W: Clone + Ord + PartialEq + One,
+    > From<PMCFG<N, T, W>> for TreeStackAutomaton<PosState<PMCFGRule<N, T, W>>, T, W>
+{
     fn from(g: PMCFG<N, T, W>) -> Self {
         let mut transitions = Vec::new();
 
@@ -150,25 +151,21 @@ impl<
                                         Some(_) => W::one(),
                                     },
                                     instruction: match previous_component[i1] {
-                                        None => {
-                                            TreeStackInstruction::Push {
-                                                n: i1,
-                                                current_val: PosState::Position(r.clone(), j, k),
-                                                new_val: PosState::Position(ri.clone(), j1, 0),
-                                            }
-                                        }
-                                        Some(j0) => {
-                                            TreeStackInstruction::Up {
-                                                n: i1,
-                                                current_val: PosState::Position(r.clone(), j, k),
-                                                old_val: PosState::Position(
-                                                    ri.clone(),
-                                                    j0,
-                                                    down_info[ri][j0].0,
-                                                ),
-                                                new_val: PosState::Position(ri.clone(), j1, 0),
-                                            }
-                                        }
+                                        None => TreeStackInstruction::Push {
+                                            n: i1,
+                                            current_val: PosState::Position(r.clone(), j, k),
+                                            new_val: PosState::Position(ri.clone(), j1, 0),
+                                        },
+                                        Some(j0) => TreeStackInstruction::Up {
+                                            n: i1,
+                                            current_val: PosState::Position(r.clone(), j, k),
+                                            old_val: PosState::Position(
+                                                ri.clone(),
+                                                j0,
+                                                down_info[ri][j0].0,
+                                            ),
+                                            new_val: PosState::Position(ri.clone(), j1, 0),
+                                        },
                                     },
                                 });
 
@@ -212,12 +209,12 @@ pub fn to_abstract_syntax_tree<A>(
     let mut abstract_syntax_tree = GornTree::new();
 
     for (address, pos_state) in tree_map {
-        let (curr_root_child, relative_address) =
-            if let Some((first, rest)) = address.split_first() {
-                (first.clone(), rest.to_vec())
-            } else {
-                continue;
-            };
+        let (curr_root_child, relative_address) = if let Some((first, rest)) = address.split_first()
+        {
+            (first.clone(), rest.to_vec())
+        } else {
+            continue;
+        };
 
         if curr_root_child != 0 {
             continue;
@@ -266,7 +263,9 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "The given tree map contains 'designated' or 'initial' nodes that are not the root!")]
+    #[should_panic(
+        expected = "The given tree map contains 'designated' or 'initial' nodes that are not the root!"
+    )]
     fn test_to_abstract_syntax_tree_invalid_tree() {
         let mut tree_map: GornTree<PosState<u8>> = GornTree::new();
         tree_map.insert(vec![], PosState::Initial);

--- a/src/automata/tree_stack_automaton/from_pmcfg.rs
+++ b/src/automata/tree_stack_automaton/from_pmcfg.rs
@@ -7,10 +7,10 @@ use std::iter::FromIterator;
 use std::vec::Vec;
 
 use self::num_traits::One;
-use grammars::pmcfg::{PMCFG, PMCFGRule, VarT};
-use recognisable::Transition;
-use automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
-use util::tree::GornTree;
+use crate::grammars::pmcfg::{PMCFG, PMCFGRule, VarT};
+use crate::recognisable::Transition;
+use crate::automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
+use crate::util::tree::GornTree;
 
 // types for analysis of derivation trees of PMCFGs
 pub type RuleCallerMap<N, T, W> = BTreeMap<PMCFGRule<N, T, W>, Vec<(usize, Vec<T>)>>;

--- a/src/automata/tree_stack_automaton/from_str.rs
+++ b/src/automata/tree_stack_automaton/from_str.rs
@@ -2,12 +2,12 @@ use nom::IResult;
 use num_traits::One;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::vec::Vec;
-use std::str::FromStr;
 use std::num::ParseIntError;
+use std::str::FromStr;
+use std::vec::Vec;
 
-use crate::recognisable::Transition;
 use crate::automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
+use crate::recognisable::Transition;
 use crate::util::parsing::parse_initial;
 
 impl<A, T, W> FromStr for TreeStackAutomaton<A, T, W>

--- a/src/automata/tree_stack_automaton/from_str.rs
+++ b/src/automata/tree_stack_automaton/from_str.rs
@@ -6,9 +6,9 @@ use std::vec::Vec;
 use std::str::FromStr;
 use std::num::ParseIntError;
 
-use recognisable::Transition;
-use automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
-use util::parsing::parse_initial;
+use crate::recognisable::Transition;
+use crate::automata::tree_stack_automaton::{TreeStack, TreeStackAutomaton, TreeStackInstruction};
+use crate::util::parsing::parse_initial;
 
 impl<A, T, W> FromStr for TreeStackAutomaton<A, T, W>
 where

--- a/src/automata/tree_stack_automaton/mod.rs
+++ b/src/automata/tree_stack_automaton/mod.rs
@@ -11,10 +11,10 @@ use std::vec::Vec;
 use num_traits::One;
 
 use integeriser::{HashIntegeriser, Integeriser};
-use recognisable::{Configuration, Item, Recognisable, Transition};
-use recognisable::automaton::{Automaton, recognise, recognise_beam};
-use util::integerisable::{Integerisable1, Integerisable2};
-use util::push_down::Pushdown;
+use crate::recognisable::{Configuration, Item, Recognisable, Transition};
+use crate::recognisable::automaton::{Automaton, recognise, recognise_beam};
+use crate::util::integerisable::{Integerisable1, Integerisable2};
+use crate::util::push_down::Pushdown;
 
 mod from_pmcfg;
 mod from_str;

--- a/src/automata/tree_stack_automaton/mod.rs
+++ b/src/automata/tree_stack_automaton/mod.rs
@@ -10,11 +10,11 @@ use std::vec::Vec;
 
 use num_traits::One;
 
-use integeriser::{HashIntegeriser, Integeriser};
+use crate::recognisable::automaton::{recognise, recognise_beam, Automaton};
 use crate::recognisable::{Configuration, Item, Recognisable, Transition};
-use crate::recognisable::automaton::{Automaton, recognise, recognise_beam};
 use crate::util::integerisable::{Integerisable1, Integerisable2};
 use crate::util::push_down::Pushdown;
+use integeriser::{HashIntegeriser, Integeriser};
 
 mod from_pmcfg;
 mod from_str;
@@ -24,7 +24,6 @@ mod tree_stack_instruction;
 pub use self::from_pmcfg::*;
 pub use self::tree_stack::*;
 pub use self::tree_stack_instruction::*;
-
 
 type TransitionMap<A, T, W> = HashMap<A, BinaryHeap<Transition<TreeStackInstruction<A>, T, W>>>;
 
@@ -42,7 +41,6 @@ where
     initial: TreeStack<usize>,
 }
 
-
 impl<A, T, W> TreeStackAutomaton<A, T, W>
 where
     A: Clone + Eq + Hash + Ord,
@@ -58,14 +56,20 @@ where
         let init: TreeStack<usize> = initial.integerise(&mut a_inter);
         let mut transition_map: TransitionMap<usize, usize, W> = HashMap::new();
 
-        for t in transitions.into_iter().map(|t| {
-            t.integerise(&mut t_inter, &mut a_inter)
-        })
+        for t in transitions
+            .into_iter()
+            .map(|t| t.integerise(&mut t_inter, &mut a_inter))
         {
             let a = match t.instruction {
-                TreeStackInstruction::Up { ref current_val, .. } |
-                TreeStackInstruction::Push { ref current_val, .. } |
-                TreeStackInstruction::Down { ref current_val, .. } => current_val.clone(),
+                TreeStackInstruction::Up {
+                    ref current_val, ..
+                }
+                | TreeStackInstruction::Push {
+                    ref current_val, ..
+                }
+                | TreeStackInstruction::Down {
+                    ref current_val, ..
+                } => current_val.clone(),
             };
 
             if !transition_map.contains_key(&a) {
@@ -119,18 +123,11 @@ where
     }
 }
 
-
 impl<A, T, W> Recognisable<T, W> for TreeStackAutomaton<A, T, W>
 where
     A: Ord + PartialEq + Clone + Hash,
     T: Clone + Eq + Hash + Ord,
-    W: One
-        + Mul<Output = W>
-        + MulAssign
-        + Clone
-        + Copy
-        + Eq
-        + Ord,
+    W: One + Mul<Output = W> + MulAssign + Clone + Copy + Eq + Ord,
 {
     type Parse = Item<TreeStack<A>, TreeStackInstruction<A>, T, W>;
 
@@ -147,18 +144,11 @@ where
     }
 }
 
-
 impl<A, T, W> Automaton<T, W> for TreeStackAutomaton<A, T, W>
 where
     A: Clone + Eq + Hash + Ord,
     T: Clone + Eq + Hash + Ord,
-    W: Clone
-        + Copy
-        + Eq
-        + Mul<Output = W>
-        + MulAssign
-        + One
-        + Ord,
+    W: Clone + Copy + Eq + Mul<Output = W> + MulAssign + One + Ord,
 {
     type Key = usize;
     type I = TreeStackInstruction<A>;
@@ -183,9 +173,8 @@ where
     }
 
     fn initial(&self) -> TreeStack<A> {
-        self.initial.map(&mut |i| {
-            self.a_integeriser.find_value(*i).unwrap().clone()
-        })
+        self.initial
+            .map(&mut |i| self.a_integeriser.find_value(*i).unwrap().clone())
     }
 
     fn item_map(
@@ -193,12 +182,14 @@ where
         i: &Item<TreeStack<usize>, TreeStackInstruction<usize>, usize, W>,
     ) -> Item<TreeStack<A>, TreeStackInstruction<A>, T, W> {
         match *i {
-            Item(Configuration {
-                 ref word,
-                 ref storage,
-                 weight,
-             },
-             ref pd) => {
+            Item(
+                Configuration {
+                    ref word,
+                    ref storage,
+                    weight,
+                },
+                ref pd,
+            ) => {
                 let pd_vec: Vec<_> = pd.clone().into();
                 let pd_unint: Vec<_> = pd_vec
                     .iter()
@@ -208,7 +199,8 @@ where
                     .collect();
                 Item(
                     Configuration {
-                        word: word.iter()
+                        word: word
+                            .iter()
                             .map(|t| self.t_integeriser.find_value(*t).unwrap().clone())
                             .collect(),
                         storage: Integerisable1::un_integerise(storage, &self.a_integeriser),
@@ -239,18 +231,11 @@ where
     }
 }
 
-
 impl<A, T, W> Display for TreeStackAutomaton<A, T, W>
 where
     A: Ord + PartialEq + Clone + Hash + Display,
     T: Clone + Eq + Debug + Hash + Ord,
-    W: One
-        + Mul<Output = W>
-        + Clone
-        + Copy
-        + Eq
-        + Ord
-        + Display,
+    W: One + Mul<Output = W> + Clone + Copy + Eq + Ord + Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut formatted_transitions = String::new();

--- a/src/automata/tree_stack_automaton/tree_stack.rs
+++ b/src/automata/tree_stack_automaton/tree_stack.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use std::hash::Hash;
 
 use integeriser::{HashIntegeriser, Integeriser};
-use util::integerisable::Integerisable1;
-use util::tree::GornTree;
+use crate::util::integerisable::Integerisable1;
+use crate::util::tree::GornTree;
 
 /// upside-down tree with a designated position (the *stack pointer*) and *nodes* of type `A`.
 #[derive(Clone, Debug)]
@@ -236,7 +236,7 @@ impl<A: Clone> TreeStack<A> {
 
         for (num, maybe_child) in self.children.iter().enumerate() {
             if let &Some(ref child) = maybe_child {
-                let (mut child_map, _) = child.to_tree();
+                let (child_map, _) = child.to_tree();
 
                 for (path, value) in child_map {
                     let mut new_path = curr_path.clone();

--- a/src/automata/tree_stack_automaton/tree_stack.rs
+++ b/src/automata/tree_stack_automaton/tree_stack.rs
@@ -1,11 +1,11 @@
 use std::cmp::Ordering;
 use std::fmt;
-use std::rc::Rc;
 use std::hash::Hash;
+use std::rc::Rc;
 
-use integeriser::{HashIntegeriser, Integeriser};
 use crate::util::integerisable::Integerisable1;
 use crate::util::tree::GornTree;
+use integeriser::{HashIntegeriser, Integeriser};
 
 /// upside-down tree with a designated position (the *stack pointer*) and *nodes* of type `A`.
 #[derive(Clone, Debug)]
@@ -35,7 +35,8 @@ impl<A> TreeStack<A> {
             Some((i, ref p)) => Some((i, Rc::new(p.map(f)))),
             None => None,
         };
-        let new_children = self.children
+        let new_children = self
+            .children
             .iter()
             .map(|o| o.clone().map(|v| Rc::new(v.map(f))))
             .collect();
@@ -107,11 +108,13 @@ impl<A> TreeStack<A> {
     /// Writes a value in the first free child position.
     pub fn push_next(self, a: A) -> Self {
         let index = {
-            match self.children
+            match self
+                .children
                 .iter()
                 .enumerate()
                 .filter(|&(_i, e)| e.is_none())
-                .next() {
+                .next()
+            {
                 None => self.children.len(),
                 Some((i, _)) => i,
             }
@@ -128,8 +131,8 @@ impl<A> TreeStack<A> {
     where
         F: Fn(&A) -> bool,
     {
-        predicate(&self.value) &&
-            self.children.iter().all(|maybe_child| {
+        predicate(&self.value)
+            && self.children.iter().all(|maybe_child| {
                 if let &Some(ref child) = maybe_child {
                     child.all(predicate)
                 } else {
@@ -264,16 +267,16 @@ impl<A: Clone + Eq + Hash> Integerisable1 for TreeStack<A> {
     }
 }
 
-
 impl<A: PartialEq> PartialEq for TreeStack<A> {
     fn eq(&self, other: &Self) -> bool {
         let comp = |p1, p2| Rc::ptr_eq(p1, p2) || p1 == p2;
-        self.value == other.value &&
-            match (&self.parent, &other.parent) {
+        self.value == other.value
+            && match (&self.parent, &other.parent) {
                 (&Some((i1, ref p1)), &Some((i2, ref p2))) => i1 == i2 && comp(p1, p2),
                 (&None, &None) => true,
                 _ => false,
-            } && self.children == other.children
+            }
+            && self.children == other.children
     }
 }
 
@@ -282,14 +285,10 @@ impl<A: Eq> Eq for TreeStack<A> {}
 impl<A: PartialOrd> PartialOrd for TreeStack<A> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.value.partial_cmp(&other.value) {
-            None |
-            Some(Ordering::Equal) => {
-                match self.parent.partial_cmp(&other.parent) {
-                    None |
-                    Some(Ordering::Equal) => self.children.partial_cmp(&other.children),
-                    x => x,
-                }
-            }
+            None | Some(Ordering::Equal) => match self.parent.partial_cmp(&other.parent) {
+                None | Some(Ordering::Equal) => self.children.partial_cmp(&other.children),
+                x => x,
+            },
             x => x,
         }
     }
@@ -298,12 +297,10 @@ impl<A: PartialOrd> PartialOrd for TreeStack<A> {
 impl<A: Ord> Ord for TreeStack<A> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.value.cmp(&other.value) {
-            Ordering::Equal => {
-                match self.parent.cmp(&other.parent) {
-                    Ordering::Equal => self.children.cmp(&other.children),
-                    x => x,
-                }
-            }
+            Ordering::Equal => match self.parent.cmp(&other.parent) {
+                Ordering::Equal => self.children.cmp(&other.children),
+                x => x,
+            },
             x => x,
         }
     }

--- a/src/automata/tree_stack_automaton/tree_stack_instruction.rs
+++ b/src/automata/tree_stack_automaton/tree_stack_instruction.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 use std::hash::Hash;
 
-use recognisable::Instruction;
-use util::integerisable::Integerisable1;
-use automata::tree_stack_automaton::TreeStack;
+use crate::recognisable::Instruction;
+use crate::util::integerisable::Integerisable1;
+use crate::automata::tree_stack_automaton::TreeStack;
 
 use integeriser::{HashIntegeriser, Integeriser};
 

--- a/src/automata/tree_stack_automaton/tree_stack_instruction.rs
+++ b/src/automata/tree_stack_automaton/tree_stack_instruction.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 use std::hash::Hash;
 
+use crate::automata::tree_stack_automaton::TreeStack;
 use crate::recognisable::Instruction;
 use crate::util::integerisable::Integerisable1;
-use crate::automata::tree_stack_automaton::TreeStack;
 
 use integeriser::{HashIntegeriser, Integeriser};
-
 
 /// Instruction on `TreeStack<A>`s.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Hash)]
@@ -28,7 +27,6 @@ pub enum TreeStackInstruction<A> {
         new_val: A,
     },
 }
-
 
 impl<A> TreeStackInstruction<A> {
     fn map<F, B>(&self, mut f: F) -> TreeStackInstruction<B>
@@ -68,7 +66,6 @@ impl<A> TreeStackInstruction<A> {
         }
     }
 }
-
 
 impl<A: Ord + PartialEq + Clone + Hash> Instruction for TreeStackInstruction<A> {
     type Storage = TreeStack<A>;
@@ -131,7 +128,6 @@ impl<A: Ord + PartialEq + Clone + Hash> Instruction for TreeStackInstruction<A> 
     }
 }
 
-
 impl<A: Clone + Eq + Hash> Integerisable1 for TreeStackInstruction<A> {
     type AInt = TreeStackInstruction<usize>;
     type I = HashIntegeriser<A>;
@@ -144,7 +140,6 @@ impl<A: Clone + Eq + Hash> Integerisable1 for TreeStackInstruction<A> {
         v.map(|i| integeriser.find_value(*i).unwrap().clone())
     }
 }
-
 
 impl<A: fmt::Display> fmt::Display for TreeStackInstruction<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -188,7 +183,7 @@ mod tests {
                     current_val: 2,
                     old_val: 4,
                     new_val: 6,
-                }
+                },
             ),
             (
                 TreeStackInstruction::Down {
@@ -200,7 +195,7 @@ mod tests {
                     current_val: 2,
                     old_val: 4,
                     new_val: 6,
-                }
+                },
             ),
             (
                 TreeStackInstruction::Push {
@@ -212,7 +207,7 @@ mod tests {
                     n: 1,
                     current_val: 2,
                     new_val: 4,
-                }
+                },
             ),
         ];
 

--- a/src/bin/cfg.rs
+++ b/src/bin/cfg.rs
@@ -1,11 +1,11 @@
-use clap::{Arg, ArgMatches, App, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use log_domain::LogDomain;
+use rustomata::automata::push_down_automaton::PushDownAutomaton;
 use rustomata::grammars::cfg::CFG;
 use rustomata::recognisable::Recognisable;
-use rustomata::automata::push_down_automaton::PushDownAutomaton;
 
-use std::io::{self, Read};
 use std::fs::File;
+use std::io::{self, Read};
 
 pub fn get_sub_command() -> App<'static, 'static> {
     SubCommand::with_name("cfg")
@@ -41,9 +41,7 @@ pub fn get_sub_command() -> App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("automaton")
                 .author("Max Korn <max.korn@tu-dresden.de>")
-                .about(
-                    "constructs a pushdown automaton from the given context-free grammar",
-                )
+                .about("constructs a pushdown automaton from the given context-free grammar")
                 .arg(
                     Arg::with_name("grammar")
                         .help("grammar file to use")

--- a/src/bin/csparsing.rs
+++ b/src/bin/csparsing.rs
@@ -163,7 +163,7 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
                 let dgmr: DiscoDopGrammar<_, _, _> = grammar_string.parse().expect("Could not parse grammar.");
                 if params.is_present("disco-lexer") {
                     let lexer = File::open(params.value_of("disco-lexer").expect("Missing lexer file as argument")).expect("could not open lexer file");
-                    let mut lexer_string = FileReader::new(lexer, grammar_is_gzipped).read().expect("could not read lexer file");
+                    let lexer_string = FileReader::new(lexer, grammar_is_gzipped).read().expect("could not read lexer file");
                     dgmr.with_lexer(lexer_string.parse().expect("Could not parse lexer file.")).into()
                 } else {
                     dgmr.with_default_lexer().into()

--- a/src/bin/csparsing.rs
+++ b/src/bin/csparsing.rs
@@ -2,12 +2,18 @@ extern crate bincode;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use flate2::{read, write, Compression};
 use log_domain::LogDomain;
-use std::{fs::File,
-          io::{stdin, stdout, Read}};
 use rustomata::grammars::lcfrs::from_discodop::DiscoDopGrammar;
-use rustomata::grammars::{lcfrs::{csparsing::{CSRepresentation, DebugResult},
-                                  Lcfrs},
-                          pmcfg::negra::{to_negra, DumpMode, noparse}};
+use rustomata::grammars::{
+    lcfrs::{
+        csparsing::{CSRepresentation, DebugResult},
+        Lcfrs,
+    },
+    pmcfg::negra::{noparse, to_negra, DumpMode},
+};
+use std::{
+    fs::File,
+    io::{stdin, stdout, Read},
+};
 
 pub fn get_sub_command(name: &str) -> App {
     SubCommand::with_name(name)
@@ -125,13 +131,16 @@ pub fn get_sub_command(name: &str) -> App {
 
 enum FileReader<R: Read> {
     Plain(R),
-    GZipped(R)
+    GZipped(R),
 }
 
 impl<R: Read> FileReader<R> {
     fn new(file: R, zipped: bool) -> Self {
-        if zipped { FileReader::GZipped(file) }
-        else { FileReader::Plain(file) }
+        if zipped {
+            FileReader::GZipped(file)
+        } else {
+            FileReader::Plain(file)
+        }
     }
 
     fn read(self) -> Result<String, ::std::io::Error> {
@@ -139,7 +148,7 @@ impl<R: Read> FileReader<R> {
         match self {
             FileReader::Plain(mut f) => {
                 f.read_to_string(&mut s)?;
-            },
+            }
             FileReader::GZipped(f) => {
                 read::GzDecoder::new(f).read_to_string(&mut s)?;
             }
@@ -151,20 +160,40 @@ impl<R: Read> FileReader<R> {
 pub fn handle_sub_matches(submatches: &ArgMatches) {
     match submatches.subcommand() {
         ("extract", Some(params)) => {
-            let grammar_is_gzipped = (params.is_present("gzipped") || params.is_present("disco-grammar")) && !params.is_present("ungzipped");
+            let grammar_is_gzipped = (params.is_present("gzipped")
+                || params.is_present("disco-grammar"))
+                && !params.is_present("ungzipped");
             let grammar_string = if let Some(path) = params.value_of("grammar") {
-                FileReader::new(File::open(path).expect("could not open grammar file"), grammar_is_gzipped).read().expect("could not read grammar file")
+                FileReader::new(
+                    File::open(path).expect("could not open grammar file"),
+                    grammar_is_gzipped,
+                )
+                .read()
+                .expect("could not read grammar file")
             } else {
-                FileReader::new(stdin(), grammar_is_gzipped).read().expect("could not read grammar file")
+                FileReader::new(stdin(), grammar_is_gzipped)
+                    .read()
+                    .expect("could not read grammar file")
             };
-            let sxlen = params.value_of("sxlen").map_or(0usize, |s| s.parse().unwrap());
+            let sxlen = params
+                .value_of("sxlen")
+                .map_or(0usize, |s| s.parse().unwrap());
 
             let gmr: Lcfrs<String, String, LogDomain<f64>> = if params.is_present("disco-grammar") {
-                let dgmr: DiscoDopGrammar<_, _, _> = grammar_string.parse().expect("Could not parse grammar.");
+                let dgmr: DiscoDopGrammar<_, _, _> =
+                    grammar_string.parse().expect("Could not parse grammar.");
                 if params.is_present("disco-lexer") {
-                    let lexer = File::open(params.value_of("disco-lexer").expect("Missing lexer file as argument")).expect("could not open lexer file");
-                    let lexer_string = FileReader::new(lexer, grammar_is_gzipped).read().expect("could not read lexer file");
-                    dgmr.with_lexer(lexer_string.parse().expect("Could not parse lexer file.")).into()
+                    let lexer = File::open(
+                        params
+                            .value_of("disco-lexer")
+                            .expect("Missing lexer file as argument"),
+                    )
+                    .expect("could not open lexer file");
+                    let lexer_string = FileReader::new(lexer, grammar_is_gzipped)
+                        .read()
+                        .expect("could not read lexer file");
+                    dgmr.with_lexer(lexer_string.parse().expect("Could not parse lexer file."))
+                        .into()
                 } else {
                     dgmr.with_default_lexer().into()
                 }
@@ -178,7 +207,8 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
                 &mut write::GzEncoder::new(stdout(), Compression::best()),
                 &CSRepresentation::new(gmr, sxlen),
                 bincode::Infinite,
-            ).unwrap()
+            )
+            .unwrap()
         }
 
         ("parse", Some(params)) => {
@@ -190,14 +220,12 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
                 Some(n) => n.parse::<usize>().unwrap(),
                 None => 1usize,
             };
-            
-            let beam_width: Option<usize>
-                = params.value_of("beam").map(|s| s.parse().unwrap());
-            let beam_threshold: Option<LogDomain<f64>>
-                = params.value_of("threshold").map(|s| s.parse().unwrap());
-            let candidates: Option<usize>
-                = params.value_of("candidates").map(|s| s.parse().unwrap());
 
+            let beam_width: Option<usize> = params.value_of("beam").map(|s| s.parse().unwrap());
+            let beam_threshold: Option<LogDomain<f64>> =
+                params.value_of("threshold").map(|s| s.parse().unwrap());
+            let candidates: Option<usize> =
+                params.value_of("candidates").map(|s| s.parse().unwrap());
 
             let csfile = File::open(params.value_of("csfile").unwrap()).unwrap();
 
@@ -205,9 +233,15 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
                 bincode::deserialize_from(&mut read::GzDecoder::new(csfile), bincode::Infinite)
                     .unwrap();
             let mut parser = csrep.build_generator();
-            if let Some(beam) = beam_width { parser.set_beam(beam) };
-            if let Some(delta) = beam_threshold { parser.set_delta(delta) };
-            if let Some(candidates) = candidates { parser.set_candidates(candidates) };
+            if let Some(beam) = beam_width {
+                parser.set_beam(beam)
+            };
+            if let Some(delta) = beam_threshold {
+                parser.set_delta(delta)
+            };
+            if let Some(candidates) = candidates {
+                parser.set_candidates(candidates)
+            };
 
             for (i, sentence) in word_strings.lines().enumerate() {
                 let (i, words) = split_line(sentence, params.is_present("with-lines"), i);
@@ -220,15 +254,15 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
                         DebugResult::Parse(t, n) => {
                             eprintln!("parse {}", n);
                             println!("{}", to_negra(&t, i, negra_mode));
-                        },
+                        }
                         DebugResult::Fallback(t, n) => {
                             eprintln!("fallback {}", n);
                             println!("{}", to_negra(&t, i, negra_mode));
-                        },
+                        }
                         DebugResult::Noparse => {
                             eprintln!("noparse 0");
                             println!("{}", noparse(&words, i, negra_mode));
-                        },
+                        }
                     }
                 } else {
                     let mut found_trees = false;
@@ -263,14 +297,19 @@ pub fn handle_sub_matches(submatches: &ArgMatches) {
     }
 }
 
-fn split_line<'a>(line: &'a str, with_line_number: bool, default_line_number: usize) -> (usize, impl Iterator<Item=&'a str> + 'a) {
+fn split_line<'a>(
+    line: &'a str,
+    with_line_number: bool,
+    default_line_number: usize,
+) -> (usize, impl Iterator<Item = &'a str> + 'a) {
     let mut word_iterator = line.split_whitespace();
-    
+
     let line_number = if with_line_number {
-        word_iterator.next()
-                     .expect("missing line number")
-                     .parse()
-                     .expect("invalid line numer")
+        word_iterator
+            .next()
+            .expect("missing line number")
+            .parse()
+            .expect("invalid line numer")
     } else {
         default_line_number
     };
@@ -278,16 +317,20 @@ fn split_line<'a>(line: &'a str, with_line_number: bool, default_line_number: us
     (line_number, word_iterator)
 }
 
-fn split_pos<'a>(words: impl Iterator<Item=&'a str> + 'a, with_pos: bool) -> (Vec<String>, DumpMode<String>) {
+fn split_pos<'a>(
+    words: impl Iterator<Item = &'a str> + 'a,
+    with_pos: bool,
+) -> (Vec<String>, DumpMode<String>) {
     if with_pos {
-        let (pos, ws) = words.map(
-            |wp| {
+        let (pos, ws) = words
+            .map(|wp| {
                 let mut it = wp.rsplitn(2, '/');
-                ( it.next().unwrap().to_string(),
-                  it.next().expect("missing pos annotation").to_string()
+                (
+                    it.next().unwrap().to_string(),
+                    it.next().expect("missing pos annotation").to_string(),
                 )
-            }
-        ).unzip();
+            })
+            .unzip();
         (pos, DumpMode::FromPos(ws))
     } else {
         (words.map(|s| s.to_string()).collect(), DumpMode::Default)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 extern crate clap;
-extern crate log_domain;
 extern crate flate2;
+extern crate log_domain;
 
 #[macro_use]
 extern crate rustomata;
@@ -9,9 +9,9 @@ use clap::App;
 
 mod approximation;
 mod cfg;
+mod csparsing;
 mod pmcfg;
 mod tree_stack_automata;
-mod csparsing;
 
 fn main() {
     let matches = App::new("rustomata")
@@ -33,5 +33,4 @@ fn main() {
         ("csparsing", Some(r_matches)) => csparsing::handle_sub_matches(r_matches),
         _ => (),
     }
-
 }

--- a/src/bin/pmcfg.rs
+++ b/src/bin/pmcfg.rs
@@ -1,13 +1,13 @@
-use clap::{Arg, ArgMatches, App, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use log_domain::LogDomain;
-use rustomata::grammars::pmcfg::PMCFG;
-use rustomata::grammars::pmcfg::negra::{to_negra, DumpMode};
-use rustomata::recognisable::Recognisable;
-use rustomata::automata::tree_stack_automaton::TreeStackAutomaton;
 use rustomata::automata::tree_stack_automaton::to_abstract_syntax_tree;
+use rustomata::automata::tree_stack_automaton::TreeStackAutomaton;
+use rustomata::grammars::pmcfg::negra::{to_negra, DumpMode};
+use rustomata::grammars::pmcfg::PMCFG;
+use rustomata::recognisable::Recognisable;
 
-use std::io::{self, Read};
 use std::fs::File;
+use std::io::{self, Read};
 
 pub fn get_sub_command() -> App<'static, 'static> {
     SubCommand::with_name("mcfg")

--- a/src/bin/tree_stack_automata.rs
+++ b/src/bin/tree_stack_automata.rs
@@ -1,15 +1,16 @@
-use clap::{Arg, ArgMatches, App, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use log_domain::LogDomain;
-use rustomata::recognisable::{Item, Recognisable};
-use rustomata::automata::tree_stack_automaton::{TreeStackAutomaton, TreeStack,
-                                                TreeStackInstruction};
-use rustomata::approximation::ApproximationStrategy;
 use rustomata::approximation::tts::TTSElement;
+use rustomata::approximation::ApproximationStrategy;
+use rustomata::automata::tree_stack_automaton::{
+    TreeStack, TreeStackAutomaton, TreeStackInstruction,
+};
 use rustomata::recognisable::coarse_to_fine::CoarseToFineRecogniser;
+use rustomata::recognisable::{Item, Recognisable};
 use std::fmt::Debug;
+use std::fs::File;
 use std::io::{self, Read};
 use std::rc::Rc;
-use std::fs::File;
 
 pub fn get_sub_command() -> App<'static, 'static> {
     SubCommand::with_name("tsa")

--- a/src/dyck/mod.rs
+++ b/src/dyck/mod.rs
@@ -18,23 +18,21 @@ pub fn recognize<A: PartialEq>(word: &[Bracket<A>]) -> bool {
             Bracket::Open(ref symbol) => {
                 stack.push(symbol);
             }
-            Bracket::Close(ref symbol) => {
-                match stack.pop() {
-                    None => return false,
-                    Some(symbol_) => {
-                        if symbol != symbol_ {
-                            return false;
-                        }
+            Bracket::Close(ref symbol) => match stack.pop() {
+                None => return false,
+                Some(symbol_) => {
+                    if symbol != symbol_ {
+                        return false;
                     }
                 }
-            }
+            },
         }
     }
 
     stack.is_empty()
 }
 
-use std::fmt::{Display, Formatter, Error};
+use std::fmt::{Display, Error, Formatter};
 
 impl<T> Display for Bracket<T>
 where
@@ -63,8 +61,11 @@ mod tests {
             assert!(super::recognize(&dyckword));
         }
 
-        assert!(super::recognize(
-            &vec![Open("one"), Close("one"), Open("two"), Close("two")],
-        ));
+        assert!(super::recognize(&vec![
+            Open("one"),
+            Close("one"),
+            Open("two"),
+            Close("two")
+        ],));
     }
 }

--- a/src/dyck/multiple/automaton/instruction.rs
+++ b/src/dyck/multiple/automaton/instruction.rs
@@ -1,7 +1,6 @@
-use std::collections::BTreeSet;
-use crate::recognisable::Instruction;
 use crate::automata::tree_stack_automaton::TreeStack;
-
+use crate::recognisable::Instruction;
+use std::collections::BTreeSet;
 
 /// An element of the tree push-down for recognizing a MDL.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -23,7 +22,6 @@ impl<T: Ord> MDTreeElem<T> {
     }
 }
 
-
 /// Instruction of an `Automaton` that recognizes multiple Dyck languages
 /// over an alphabet of elements in `T`.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Serialize, Deserialize)]
@@ -40,7 +38,6 @@ pub enum MultipleDyckInstruction<T: Ord> {
     Down(T),
 }
 
-
 impl<T: Clone + Ord> Instruction for MultipleDyckInstruction<T> {
     type Storage = TreeStack<MDTreeElem<T>>;
 
@@ -54,23 +51,22 @@ impl<T: Clone + Ord> Instruction for MultipleDyckInstruction<T> {
                     let mut c = cell.clone();
                     c.remove(symbol);
                     MDTreeElem::Node(Some(symbol.clone()), c)
-                }) { // if node is blocked check the set in it and go up
+                }) {
+                    // if node is blocked check the set in it and go up
                     Ok(ts) => vec![ts],
                     Err(ts) => {
                         let ts_ = ts.up(position).ok().unwrap();
-                        if let Some(mut succset) =
-                            {
-                                if let MDTreeElem::Node(None, ref subset) = *ts_.current_symbol() {
-                                    if subset.contains(symbol) {
-                                        Some(subset.clone())
-                                    } else {
-                                        None
-                                    }
+                        if let Some(mut succset) = {
+                            if let MDTreeElem::Node(None, ref subset) = *ts_.current_symbol() {
+                                if subset.contains(symbol) {
+                                    Some(subset.clone())
                                 } else {
                                     None
                                 }
+                            } else {
+                                None
                             }
-                        {
+                        } {
                             succset.remove(symbol);
                             vec![ts_.set(MDTreeElem::Node(Some(symbol.clone()), succset))]
                         } else {
@@ -85,9 +81,10 @@ impl<T: Clone + Ord> Instruction for MultipleDyckInstruction<T> {
                 // option 1: push a new child
                 let mut subset = cell.clone();
                 subset.remove(symbol);
-                succ.push(ts.clone().push_next(
-                    MDTreeElem::Node(Some(symbol.clone()), subset),
-                ));
+                succ.push(
+                    ts.clone()
+                        .push_next(MDTreeElem::Node(Some(symbol.clone()), subset)),
+                );
 
                 // option 2: up nondeterministcally
                 for ts_ in ts.ups() {
@@ -95,9 +92,10 @@ impl<T: Clone + Ord> Instruction for MultipleDyckInstruction<T> {
                         if subset.contains(symbol) {
                             let mut succset = subset.clone();
                             succset.remove(symbol);
-                            succ.push(ts_.clone().set(
-                                MDTreeElem::Node(Some(symbol.clone()), succset),
-                            ));
+                            succ.push(
+                                ts_.clone()
+                                    .set(MDTreeElem::Node(Some(symbol.clone()), succset)),
+                            );
                         }
                     }
                 }
@@ -111,9 +109,11 @@ impl<T: Clone + Ord> Instruction for MultipleDyckInstruction<T> {
                             Vec::new()
                         } else {
                             // down
-                            match ts.clone()
+                            match ts
+                                .clone()
                                 .set(MDTreeElem::Node(None, subset.clone()))
-                                .down() {
+                                .down()
+                            {
                                 Ok(t) => vec![t],
                                 _ => Vec::new(),
                             }

--- a/src/dyck/multiple/automaton/instruction.rs
+++ b/src/dyck/multiple/automaton/instruction.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
-use recognisable::Instruction;
-use automata::tree_stack_automaton::TreeStack;
+use crate::recognisable::Instruction;
+use crate::automata::tree_stack_automaton::TreeStack;
 
 
 /// An element of the tree push-down for recognizing a MDL.

--- a/src/dyck/multiple/automaton/mod.rs
+++ b/src/dyck/multiple/automaton/mod.rs
@@ -1,11 +1,11 @@
 pub mod instruction;
 
-use std::collections::{BinaryHeap, HashMap};
-pub use crate::dyck::multiple::automaton::instruction::{MDTreeElem, MultipleDyckInstruction};
-use crate::util::partition::Partition;
-use crate::recognisable::Transition;
 use crate::automata::tree_stack_automaton::TreeStack;
+pub use crate::dyck::multiple::automaton::instruction::{MDTreeElem, MultipleDyckInstruction};
 use crate::recognisable::Configuration;
+use crate::recognisable::Transition;
+use crate::util::partition::Partition;
+use std::collections::{BinaryHeap, HashMap};
 
 use crate::dyck::Bracket;
 use crate::recognisable::automaton::{Automaton, TransitionMap};
@@ -46,7 +46,9 @@ impl<T: Clone + Ord> MultipleDyckAutomaton<T> {
 
         let mut map = HashMap::new();
         map.insert((), heap);
-        MultipleDyckAutomaton { transitions: Rc::new(map) }
+        MultipleDyckAutomaton {
+            transitions: Rc::new(map),
+        }
     }
 
     /// Constructs a tree-stack automaton that recognizes a sorted multiple Dyck language.
@@ -78,7 +80,9 @@ impl<T: Clone + Ord> MultipleDyckAutomaton<T> {
 
         let mut map = HashMap::new();
         map.insert((), heap);
-        MultipleDyckAutomaton { transitions: Rc::new(map) }
+        MultipleDyckAutomaton {
+            transitions: Rc::new(map),
+        }
     }
 }
 
@@ -125,10 +129,10 @@ where
     }
 
     fn is_terminal(&self, c: &Configuration<TreeStack<MDTreeElem<T>>, Bracket<T>, u8>) -> bool {
-        c.word.is_empty() && c.storage.is_at_bottom() &&
-            c.storage.all(
-                &|node: &MDTreeElem<T>| -> bool { node.is_empty() },
-            )
+        c.word.is_empty()
+            && c.storage.is_at_bottom()
+            && c.storage
+                .all(&|node: &MDTreeElem<T>| -> bool { node.is_empty() })
     }
 
     fn transition_map(&self) -> Rc<TransitionMap<Self::Key, Self::IInt, Self::TInt, u8>> {

--- a/src/dyck/multiple/automaton/mod.rs
+++ b/src/dyck/multiple/automaton/mod.rs
@@ -1,16 +1,16 @@
 pub mod instruction;
 
 use std::collections::{BinaryHeap, HashMap};
-pub use dyck::multiple::automaton::instruction::{MDTreeElem, MultipleDyckInstruction};
-use util::partition::Partition;
-use recognisable::Transition;
-use automata::tree_stack_automaton::TreeStack;
-use recognisable::Configuration;
+pub use crate::dyck::multiple::automaton::instruction::{MDTreeElem, MultipleDyckInstruction};
+use crate::util::partition::Partition;
+use crate::recognisable::Transition;
+use crate::automata::tree_stack_automaton::TreeStack;
+use crate::recognisable::Configuration;
 
-use dyck::Bracket;
-use recognisable::automaton::{Automaton, TransitionMap};
+use crate::dyck::Bracket;
+use crate::recognisable::automaton::{Automaton, TransitionMap};
 
-use recognisable::Item;
+use crate::recognisable::Item;
 use std::rc::Rc;
 type MDTransition<T> = Transition<MultipleDyckInstruction<T>, Bracket<T>, u8>;
 
@@ -82,7 +82,7 @@ impl<T: Clone + Ord> MultipleDyckAutomaton<T> {
     }
 }
 
-use recognisable::Instruction;
+use crate::recognisable::Instruction;
 
 impl<T> Automaton<Bracket<T>, u8> for MultipleDyckAutomaton<T>
 where

--- a/src/dyck/multiple/mod.rs
+++ b/src/dyck/multiple/mod.rs
@@ -1,8 +1,8 @@
 mod automaton;
 use crate::dyck::multiple::automaton::MultipleDyckAutomaton;
-use crate::util::partition::Partition;
 pub use crate::dyck::Bracket;
 use crate::recognisable::automaton::recognise;
+use crate::util::partition::Partition;
 
 /// An object that represents the mutliple Dyck language of an alphabet Σ with respect to
 /// a partition of Σ.
@@ -79,7 +79,8 @@ mod test {
         let partition = Partition::new(vec![
             vec![1, 2].into_iter().collect(),
             vec![3, 4].into_iter().collect(),
-        ]).unwrap();
+        ])
+        .unwrap();
 
         let mdl = MultipleDyckLanguage::new(partition);
 
@@ -100,7 +101,7 @@ mod test {
                 Close(3),
             ],
         ];
-        
+
         for not_dyckword in not_words {
             assert!(!mdl.recognize(&not_dyckword));
         }
@@ -111,7 +112,8 @@ mod test {
         let partition = Partition::new(vec![
             vec![1, 2].into_iter().collect(),
             vec![3, 4].into_iter().collect(),
-        ]).unwrap();
+        ])
+        .unwrap();
 
         let sort = |i: &usize| -> usize {
             if vec![1usize, 2usize].contains(i) {

--- a/src/dyck/multiple/mod.rs
+++ b/src/dyck/multiple/mod.rs
@@ -1,8 +1,8 @@
 mod automaton;
-use dyck::multiple::automaton::MultipleDyckAutomaton;
-use util::partition::Partition;
-pub use dyck::Bracket;
-use recognisable::automaton::recognise;
+use crate::dyck::multiple::automaton::MultipleDyckAutomaton;
+use crate::util::partition::Partition;
+pub use crate::dyck::Bracket;
+use crate::recognisable::automaton::recognise;
 
 /// An object that represents the mutliple Dyck language of an alphabet Σ with respect to
 /// a partition of Σ.
@@ -38,7 +38,7 @@ impl<'a, T: Clone + Eq + Ord> MultipleDyckLanguage<T> {
 mod test {
     use super::Bracket::*;
     use super::MultipleDyckLanguage;
-    use util::partition::Partition;
+    use crate::util::partition::Partition;
 
     #[test]
     fn mutliple_dyck_language() {

--- a/src/grammars/cfg/from_pmcfg.rs
+++ b/src/grammars/cfg/from_pmcfg.rs
@@ -1,5 +1,5 @@
-use grammars::pmcfg::*;
-use grammars::cfg::{LetterT, CFGComposition, CFGRule, CFG};
+use crate::grammars::pmcfg::*;
+use crate::grammars::cfg::{LetterT, CFGComposition, CFGRule, CFG};
 
 impl<
     N: Clone + Ord + PartialEq,

--- a/src/grammars/cfg/from_pmcfg.rs
+++ b/src/grammars/cfg/from_pmcfg.rs
@@ -1,11 +1,9 @@
+use crate::grammars::cfg::{CFGComposition, CFGRule, LetterT, CFG};
 use crate::grammars::pmcfg::*;
-use crate::grammars::cfg::{LetterT, CFGComposition, CFGRule, CFG};
 
-impl<
-    N: Clone + Ord + PartialEq,
-    T: Clone + Ord + PartialEq,
-    W: Clone + Ord + PartialEq,
-> From<PMCFG<N, T, W>> for CFG<N, T, W> {
+impl<N: Clone + Ord + PartialEq, T: Clone + Ord + PartialEq, W: Clone + Ord + PartialEq>
+    From<PMCFG<N, T, W>> for CFG<N, T, W>
+{
     fn from(pmcfg: PMCFG<N, T, W>) -> CFG<N, T, W> {
         let mut rules = Vec::new();
 
@@ -29,11 +27,12 @@ impl<
                     }
                     _ => panic!("[ERROR] Access to wrong component in rule."),
                 }
-
             }
             rules.push(CFGRule {
                 head: r.head.clone(),
-                composition: CFGComposition { composition: new_composition },
+                composition: CFGComposition {
+                    composition: new_composition,
+                },
                 weight: r.weight.clone(),
             });
         }

--- a/src/grammars/cfg/from_str.rs
+++ b/src/grammars/cfg/from_str.rs
@@ -3,8 +3,8 @@ use num_traits::One;
 use std::fmt::Debug;
 use std::str::{FromStr, from_utf8};
 
-use grammars::cfg::{CFG, CFGComposition, CFGRule, LetterT};
-use util::parsing::*;
+use crate::grammars::cfg::{CFG, CFGComposition, CFGRule, LetterT};
+use crate::util::parsing::*;
 
 impl<N, T, W> FromStr for CFG<N, T, W>
 where

--- a/src/grammars/cfg/from_str.rs
+++ b/src/grammars/cfg/from_str.rs
@@ -1,9 +1,9 @@
-use nom::{IResult, is_space};
+use nom::{is_space, IResult};
 use num_traits::One;
 use std::fmt::Debug;
-use std::str::{FromStr, from_utf8};
+use std::str::{from_utf8, FromStr};
 
-use crate::grammars::cfg::{CFG, CFGComposition, CFGRule, LetterT};
+use crate::grammars::cfg::{CFGComposition, CFGRule, LetterT, CFG};
 use crate::util::parsing::*;
 
 impl<N, T, W> FromStr for CFG<N, T, W>
@@ -54,33 +54,29 @@ where
 {
     do_parse!(
         input,
-        head: parse_token >>
-        take_while!(is_space) >>
-        alt!(tag!("→") | tag!("->") | tag!("=>")) >>
-        take_while!(is_space) >>
-        composition: parse_composition >>
-        take_while!(is_space) >>
-        weight_o: opt!(
-            complete!(
-                do_parse!(
-                    tag!("#") >>
-                    take_while!(is_space) >>
-                    weight_s: map_res!(is_not!(" "), from_utf8) >>
-                    weight: expr_res!(weight_s.parse()) >>
-                    (weight)
-                )
-            )
-        ) >>
-        take_while!(is_space) >>
-        alt!(
-            eof!() |
-            preceded!(tag!("%"), take_while!(|_| true))
-        ) >>
-        (CFGRule {
-            head: head,
-            composition: CFGComposition { composition: composition },
-            weight: weight_o.unwrap_or(W::one()),
-        })
+        head: parse_token
+            >> take_while!(is_space)
+            >> alt!(tag!("→") | tag!("->") | tag!("=>"))
+            >> take_while!(is_space)
+            >> composition: parse_composition
+            >> take_while!(is_space)
+            >> weight_o:
+                opt!(complete!(do_parse!(
+                    tag!("#")
+                        >> take_while!(is_space)
+                        >> weight_s: map_res!(is_not!(" "), from_utf8)
+                        >> weight: expr_res!(weight_s.parse())
+                        >> (weight)
+                )))
+            >> take_while!(is_space)
+            >> alt!(eof!() | preceded!(tag!("%"), take_while!(|_| true)))
+            >> (CFGRule {
+                head: head,
+                composition: CFGComposition {
+                    composition: composition
+                },
+                weight: weight_o.unwrap_or(W::one()),
+            })
     )
 }
 
@@ -93,21 +89,21 @@ where
 {
     do_parse!(
         input,
-        result: alt!(
-            do_parse!(
-                tag!("Nt") >>
-                take_while!(is_space) >>
-                token: parse_token >>
-                (LetterT::Label(token))
-            ) |
-            do_parse!(
-                tag!("T") >>
-                take_while!(is_space) >>
-                token: parse_token >>
-                (LetterT::Value(token))
+        result:
+            alt!(
+                do_parse!(
+                    tag!("Nt")
+                        >> take_while!(is_space)
+                        >> token: parse_token
+                        >> (LetterT::Label(token))
+                ) | do_parse!(
+                    tag!("T")
+                        >> take_while!(is_space)
+                        >> token: parse_token
+                        >> (LetterT::Value(token))
+                )
             )
-        ) >>
-        (result)
+            >> (result)
     )
 }
 
@@ -170,8 +166,7 @@ pub mod tests {
 
         for illegal_input in illegal_inputs {
             match parse_letter_t::<u8, u8>(illegal_input.as_bytes()) {
-                IResult::Done(_, _) |
-                IResult::Incomplete(_) => {
+                IResult::Done(_, _) | IResult::Incomplete(_) => {
                     panic!("Was able to parse the illegal input \'{}\'", illegal_input)
                 }
                 IResult::Error(_) => (),
@@ -185,13 +180,10 @@ pub mod tests {
 
         for incomplete_input in incomplete_inputs {
             match parse_letter_t::<char, char>(incomplete_input.as_bytes()) {
-                IResult::Done(_, _) |
-                IResult::Error(_) => {
-                    panic!(
-                        "The input was not handled as incomplete: \'{}\'",
-                        incomplete_input
-                    )
-                }
+                IResult::Done(_, _) | IResult::Error(_) => panic!(
+                    "The input was not handled as incomplete: \'{}\'",
+                    incomplete_input
+                ),
                 IResult::Incomplete(_) => (),
             }
         }
@@ -201,7 +193,9 @@ pub mod tests {
     fn test_parse_cfg_rule_legal_input() {
         let rule = CFGRule {
             head: 'S',
-            composition: CFGComposition { composition: vec![LetterT::Value('a')] },
+            composition: CFGComposition {
+                composition: vec![LetterT::Value('a')],
+            },
             weight: 1.0,
         };
         let legal_inputs = vec![
@@ -236,8 +230,7 @@ pub mod tests {
 
         for illegal_input in illegal_inputs {
             match parse_cfg_rule::<char, char, f32>(illegal_input.as_bytes()) {
-                IResult::Done(_, _) |
-                IResult::Incomplete(_) => {
+                IResult::Done(_, _) | IResult::Incomplete(_) => {
                     panic!("Was able to parse the illegal input \'{}\'", illegal_input)
                 }
                 IResult::Error(_) => (),
@@ -264,7 +257,9 @@ pub mod tests {
     fn test_cfg_rule_from_str_legal_input() {
         let control_rule = CFGRule {
             head: 'S',
-            composition: CFGComposition { composition: vec![LetterT::Value('a')] },
+            composition: CFGComposition {
+                composition: vec![LetterT::Value('a')],
+            },
             weight: 1.0,
         };
 
@@ -295,7 +290,9 @@ pub mod tests {
 
         let rule_s0 = CFGRule {
             head: 'S',
-            composition: CFGComposition { composition: vec![LetterT::Label('A')] },
+            composition: CFGComposition {
+                composition: vec![LetterT::Label('A')],
+            },
             weight: 1.0,
         };
         let rule_a0 = CFGRule {
@@ -311,7 +308,9 @@ pub mod tests {
         };
         let rule_a1 = CFGRule {
             head: 'A',
-            composition: CFGComposition { composition: vec![LetterT::Value('a')] },
+            composition: CFGComposition {
+                composition: vec![LetterT::Value('a')],
+            },
             weight: 0.4,
         };
         let rule_b0 = CFGRule {
@@ -327,7 +326,9 @@ pub mod tests {
         };
         let rule_b1 = CFGRule {
             head: 'B',
-            composition: CFGComposition { composition: vec![LetterT::Value('b')] },
+            composition: CFGComposition {
+                composition: vec![LetterT::Value('b')],
+            },
             weight: 0.4,
         };
         let control_grammar = CFG {

--- a/src/grammars/cfg/mod.rs
+++ b/src/grammars/cfg/mod.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-mod from_str;
 mod from_pmcfg;
+mod from_str;
 
 /// Variable or terminal symbol in a CFG.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
@@ -19,7 +19,9 @@ pub struct CFGComposition<N, T> {
 
 impl<N, T> From<Vec<LetterT<N, T>>> for CFGComposition<N, T> {
     fn from(encapsulated_value: Vec<LetterT<N, T>>) -> Self {
-        CFGComposition { composition: encapsulated_value }
+        CFGComposition {
+            composition: encapsulated_value,
+        }
     }
 }
 
@@ -122,9 +124,7 @@ impl<N: fmt::Display, T: fmt::Display, W: fmt::Display> fmt::Display for CFGRule
         write!(
             f,
             "\"{}\" → {}  # {}",
-            self.head,
-            self.composition,
-            self.weight
+            self.head, self.composition, self.weight
         )
     }
 }

--- a/src/grammars/lcfrs/conversion.rs
+++ b/src/grammars/lcfrs/conversion.rs
@@ -1,7 +1,7 @@
 /// This module contains the implementation of the construction of an
 /// LCFRS for each MCFG.
 
-use grammars::{ pmcfg::{PMCFGRule, VarT}, mcfg::Mcfg };
+use crate::grammars::{ pmcfg::{PMCFGRule, VarT}, mcfg::Mcfg };
 use std::{ collections::{BTreeSet, HashMap}, hash::Hash };
 use super::*;
 
@@ -99,7 +99,7 @@ fn to_lcfrs_rule<N, T, W>(
 where
     N: Hash + Eq,
 {
-    use grammars::pmcfg::Composition;
+    use crate::grammars::pmcfg::Composition;
 
     let PMCFGRule {
         head,

--- a/src/grammars/lcfrs/csparsing/automaton/chart.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/chart.rs
@@ -1,33 +1,33 @@
-use super::{StateT, RangeT};
-use std::mem::{zeroed};
-use std::ops::{AddAssign};
+use super::{RangeT, StateT};
 use num_traits::Zero;
+use std::mem::zeroed;
+use std::ops::AddAssign;
 
 /// A chart for cfg parsing.
 #[derive(Debug, Clone)]
 pub struct DenseChart<W>(
-    Vec<u16>,           // no. of saved nonterminals per span
-    Vec<(StateT, W)>,   // nonterminals with viterbi weigh per span (max <beam> entries)
-    Vec<W>,             // viterbi weight per span and nonterminal
-    usize,              // n
-    usize,              // states
-    u16                 // max no. of constituents per span
+    Vec<u16>,         // no. of saved nonterminals per span
+    Vec<(StateT, W)>, // nonterminals with viterbi weigh per span (max <beam> entries)
+    Vec<W>,           // viterbi weight per span and nonterminal
+    usize,            // n
+    usize,            // states
+    u16,              // max no. of constituents per span
 );
 
 pub fn chart_size(n: usize) -> usize {
-    n * (n+1) / 2
+    n * (n + 1) / 2
 }
 pub fn chart_size_with_states(n: usize, states: usize) -> usize {
-    n * (n+1) * states / 2
+    n * (n + 1) * states / 2
 }
 
 pub fn index(i: RangeT, j: RangeT, n: usize) -> usize {
     let (i, j) = (i as usize, j as usize);
-    (n * (n+1) - (n - (j-i) + 1) * (n - (j-i) + 2)) / 2 + i
+    (n * (n + 1) - (n - (j - i) + 1) * (n - (j - i) + 2)) / 2 + i
 }
 pub fn index_with_state(i: RangeT, j: RangeT, q: StateT, n: usize, states: usize) -> usize {
     let (i, j, q) = (i as usize, j as usize, q as usize);
-    ((n * (n+1) - (n - (j-i) + 1) * (n - (j-i) + 2)) / 2 + i) * states + q
+    ((n * (n + 1) - (n - (j - i) + 1) * (n - (j - i) + 2)) / 2 + i) * states + q
 }
 
 impl<W: Copy> DenseChart<W> {
@@ -35,7 +35,7 @@ impl<W: Copy> DenseChart<W> {
     /// All data structures are initialized with zeroes.
     pub fn new(n: usize, states: usize, bt_per_cell: usize) -> Self
     where
-        W: Zero
+        W: Zero,
     {
         assert!(bt_per_cell <= u16::max_value() as usize);
         DenseChart(
@@ -44,7 +44,7 @@ impl<W: Copy> DenseChart<W> {
             vec![W::zero(); chart_size_with_states(n, states)],
             n,
             states,
-            bt_per_cell as u16
+            bt_per_cell as u16,
         )
     }
 
@@ -62,18 +62,27 @@ impl<W: Copy> DenseChart<W> {
     /// Gets weight for specific constituent and span.
     pub fn get_weight(&self, i: RangeT, j: RangeT, q: StateT) -> Option<W>
     where
-        W: PartialEq + Zero
+        W: PartialEq + Zero,
     {
         let w = self.2[index_with_state(i, j, q, self.3, self.4)];
-        if w == W::zero() { None }
-        else { Some(w) }
+        if w == W::zero() {
+            None
+        } else {
+            Some(w)
+        }
     }
 
-    pub fn get_best(&self, i: RangeT, j: RangeT) -> Option<(StateT, W)> where W: Zero + PartialEq {
+    pub fn get_best(&self, i: RangeT, j: RangeT) -> Option<(StateT, W)>
+    where
+        W: Zero + PartialEq,
+    {
         let index = index(i, j, self.3) * self.5 as usize;
         let (state, w) = self.1[index];
-        if w == W::zero() { None }
-        else { Some((state, w)) }
+        if w == W::zero() {
+            None
+        } else {
+            Some((state, w))
+        }
     }
 }
 
@@ -85,7 +94,11 @@ impl<W> DenseChart<W> {
     }
 
     /// Iterates all constituents for a span.
-    pub fn iterate_nont<'a>(&'a self, i: RangeT, j: RangeT) -> impl 'a + Iterator<Item=&'a (StateT, W)> {
+    pub fn iterate_nont<'a>(
+        &'a self,
+        i: RangeT,
+        j: RangeT,
+    ) -> impl 'a + Iterator<Item = &'a (StateT, W)> {
         let tri_index = index(i, j, self.3);
         let first_index = tri_index * self.5 as usize;
         let last_index = first_index + self.0[tri_index] as usize;

--- a/src/grammars/lcfrs/csparsing/automaton/estimates.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/estimates.rs
@@ -1,7 +1,7 @@
 use super::{Automaton, RangeT, StateT};
-use std::{ collections::BinaryHeap, hash::Hash, ops::Mul };
-use num_traits::{Zero, One};
+use num_traits::{One, Zero};
 use std::mem::replace;
+use std::{collections::BinaryHeap, hash::Hash, ops::Mul};
 
 /// Sx inside estimation for the cfg. approximation.
 // Values up to spans of length `n` and for `q` states are stored in a
@@ -17,27 +17,47 @@ struct SxInside<W>(Vec<W>, usize);
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SxOutside<W>(Vec<W>, usize, usize);
 
-impl<W: Zero + Copy + Ord + Mul<Output=W>> SxInside<W> {
-    fn index(&self, q: StateT, range: RangeT) -> usize { self.1 * (range - 1) as usize + q as usize}
+impl<W: Zero + Copy + Ord + Mul<Output = W>> SxInside<W> {
+    fn index(&self, q: StateT, range: RangeT) -> usize {
+        self.1 * (range - 1) as usize + q as usize
+    }
 
-    fn with_capacity(states: usize, maxrange: usize) -> Self { Self(vec![W::zero(); states * maxrange], states) }
+    fn with_capacity(states: usize, maxrange: usize) -> Self {
+        Self(vec![W::zero(); states * maxrange], states)
+    }
 
     fn insert(&mut self, q: StateT, range: RangeT, weight: W) -> bool {
         let index = self.index(q, range);
         let w = &mut self.0[index];
-        if *w == W::zero() { *w = weight; true } else { false }
+        if *w == W::zero() {
+            *w = weight;
+            true
+        } else {
+            false
+        }
     }
 
     fn get(&self, q: StateT, range: RangeT) -> Option<W> {
         let w = self.0[self.index(q, range)];
-        if w == W::zero() { None } else { Some(w) }
+        if w == W::zero() {
+            None
+        } else {
+            Some(w)
+        }
     }
 
-    fn iterate_states<'a>(&'a self, range_size: RangeT) -> impl 'a + Iterator<Item=(StateT, W)> {
+    fn iterate_states<'a>(&'a self, range_size: RangeT) -> impl 'a + Iterator<Item = (StateT, W)> {
         let start = (range_size as usize - 1) * self.1;
-        self.0[start..(start+self.1)].iter().enumerate().filter_map(
-            |(q, w)| if *w != W::zero() { Some((q as StateT, *w)) } else { None }
-        )
+        self.0[start..(start + self.1)]
+            .iter()
+            .enumerate()
+            .filter_map(|(q, w)| {
+                if *w != W::zero() {
+                    Some((q as StateT, *w))
+                } else {
+                    None
+                }
+            })
     }
 
     /// Constructs a structure storing the Sx inside estimate for the given cfg.
@@ -48,29 +68,43 @@ impl<W: Zero + Copy + Ord + Mul<Output=W>> SxInside<W> {
 
         for range_size in 1..=maxrange {
             if range_size == 1 {
-                queue.extend(automaton.2.values().flat_map(|v| v.iter().map(|&(_, (w, q))| (w, q))));
+                queue.extend(
+                    automaton
+                        .2
+                        .values()
+                        .flat_map(|v| v.iter().map(|&(_, (w, q))| (w, q))),
+                );
             }
 
             for left_portion in 1..range_size {
                 let right_portion = range_size - left_portion;
                 for (ql, wl) in insides.iterate_states(left_portion) {
-                    queue.extend(
-                        automaton.0[ql as usize].iter().filter_map(
-                            |&(_, qr, (w0, q0))|
-                            insides.get(qr, right_portion).map(move |wr| (wl * w0 * wr, q0))
-                        )
-                    );
+                    queue.extend(automaton.0[ql as usize].iter().filter_map(
+                        |&(_, qr, (w0, q0))| {
+                            insides
+                                .get(qr, right_portion)
+                                .map(move |wr| (wl * w0 * wr, q0))
+                        },
+                    ));
                 }
             }
 
             let mut filter = vec![false; insides.1];
             while let Some((w1, q1)) = queue.pop() {
-                if replace(&mut filter[q1 as usize], true) { continue; }
+                if replace(&mut filter[q1 as usize], true) {
+                    continue;
+                }
                 insides.insert(q1, range_size, w1);
                 queue.extend(
-                    automaton.1[q1 as usize].iter().filter_map(
-                        |&(_, (w0, q0))| if !filter[q0 as usize] { Some((w0, q0)) } else { None }
-                    )
+                    automaton.1[q1 as usize]
+                        .iter()
+                        .filter_map(|&(_, (w0, q0))| {
+                            if !filter[q0 as usize] {
+                                Some((w0, q0))
+                            } else {
+                                None
+                            }
+                        }),
                 );
             }
         }
@@ -78,30 +112,53 @@ impl<W: Zero + Copy + Ord + Mul<Output=W>> SxInside<W> {
     }
 }
 
-impl<W: Copy + Ord + Mul<Output=W> + Zero> SxOutside<W> {
+impl<W: Copy + Ord + Mul<Output = W> + Zero> SxOutside<W> {
     fn index(&self, q: StateT, i: RangeT, j: RangeT) -> usize {
-        ((self.1 * (self.1+1) - (self.1 - (j-i) as usize + 1) * (self.1 - (j-i) as usize + 2)) / 2 + i as usize) * self.2 + q as usize
+        ((self.1 * (self.1 + 1)
+            - (self.1 - (j - i) as usize + 1) * (self.1 - (j - i) as usize + 2))
+            / 2
+            + i as usize)
+            * self.2
+            + q as usize
     }
     fn index_usize(&self, q: StateT, i: usize, j: usize) -> usize {
-        ((self.1 * (self.1+1) - (self.1 - (j-i) + 1) * (self.1 - (j-i) + 2)) / 2 + i) * self.2 + q as usize
+        ((self.1 * (self.1 + 1) - (self.1 - (j - i) + 1) * (self.1 - (j - i) + 2)) / 2 + i) * self.2
+            + q as usize
     }
 
     fn with_capacity(states: usize, maxrange: usize) -> Self {
-        Self(vec![W::zero(); states * maxrange * (maxrange + 1) / 2], maxrange, states)
+        Self(
+            vec![W::zero(); states * maxrange * (maxrange + 1) / 2],
+            maxrange,
+            states,
+        )
     }
 
     fn insert(&mut self, q: StateT, i: RangeT, j: RangeT, weight: W) -> bool {
         let index = self.index(q, i, j);
         let w = &mut self.0[index];
-        if *w == W::zero() { *w = weight; true } else { false }
+        if *w == W::zero() {
+            *w = weight;
+            true
+        } else {
+            false
+        }
     }
 
-    fn iterate_states<'a>(&'a self, left_front: RangeT, right_front: RangeT) -> impl 'a + Iterator<Item=(StateT, W)> {
+    fn iterate_states<'a>(
+        &'a self,
+        left_front: RangeT,
+        right_front: RangeT,
+    ) -> impl 'a + Iterator<Item = (StateT, W)> {
         let start = self.index(0, left_front, right_front);
         let end = start + self.2;
-        self.0[start..end].iter().enumerate().filter_map(
-            |(q, w)| if *w != W::zero() { Some((q as StateT, *w)) } else { None }
-        )
+        self.0[start..end].iter().enumerate().filter_map(|(q, w)| {
+            if *w != W::zero() {
+                Some((q as StateT, *w))
+            } else {
+                None
+            }
+        })
     }
 
     /// Fetch the Sx outside estimation for the constituent `q` spanning `(i, j)`.
@@ -111,66 +168,72 @@ impl<W: Copy + Ord + Mul<Output=W> + Zero> SxOutside<W> {
     /// * `Some(w)`, where w is the outside estimate.
     pub fn get(&self, q: StateT, i: usize, j: usize, n: usize) -> Option<W>
     where
-        W: One
+        W: One,
     {
-        if i + n - j >= self.1 { return Some(W::one()); }
+        if i + n - j >= self.1 {
+            return Some(W::one());
+        }
         let w = self.0[self.index_usize(q, i, j + self.1 - n)];
-        if w == W::zero() { None } else { Some(w) }
+        if w == W::zero() {
+            None
+        } else {
+            Some(w)
+        }
     }
 
     /// Constructs a structure storing the Sx outside estimate for the given cfg.
     /// The estimates are computed up to a given span.
     pub fn from_automaton<T: Hash + Eq>(automaton: &Automaton<T, W>, maxrange: RangeT) -> Self
     where
-        W: One
+        W: One,
     {
         let insides = SxInside::from_automaton(automaton, maxrange);
         let mut outsides = Self::with_capacity(automaton.0.len(), maxrange as usize);
         let mut queue: BinaryHeap<(W, StateT)> = BinaryHeap::new();
-        
+
         for range_size in (1..=maxrange).rev() {
-            for left_front in 0..=(maxrange-range_size) {
+            for left_front in 0..=(maxrange - range_size) {
                 let right_front = left_front + range_size;
-                
+
                 if range_size == maxrange {
                     queue.push((W::one(), automaton.7));
                 }
 
                 for extended_left_front in 0..left_front {
                     for (q0, wo) in outsides.iterate_states(extended_left_front, right_front) {
-                        queue.extend(
-                            automaton.3[q0 as usize].iter().filter_map(
-                                |&(_, ql, qr, w0)| {
-                                    let wl = insides.get(ql, left_front - extended_left_front)?;
-                                    Some((wl * w0 * wo, qr))
-                                }
-                            )
-                        )
+                        queue.extend(automaton.3[q0 as usize].iter().filter_map(
+                            |&(_, ql, qr, w0)| {
+                                let wl = insides.get(ql, left_front - extended_left_front)?;
+                                Some((wl * w0 * wo, qr))
+                            },
+                        ))
                     }
                 }
 
-                for extended_right_front in (right_front+1)..=maxrange {
+                for extended_right_front in (right_front + 1)..=maxrange {
                     for (q0, wo) in outsides.iterate_states(left_front, extended_right_front) {
-                        queue.extend(
-                            automaton.3[q0 as usize].iter().filter_map(
-                                |&(_, ql, qr, w0)| {
-                                    let wr = insides.get(qr, extended_right_front - right_front)?;
-                                    Some((w0 * wr * wo, ql))
-                                }
-                            )
-                        )
+                        queue.extend(automaton.3[q0 as usize].iter().filter_map(
+                            |&(_, ql, qr, w0)| {
+                                let wr = insides.get(qr, extended_right_front - right_front)?;
+                                Some((w0 * wr * wo, ql))
+                            },
+                        ))
                     }
                 }
 
                 let mut filter = vec![false; outsides.2];
                 while let Some((w0, q0)) = queue.pop() {
-                    if replace(&mut filter[q0 as usize], true) { continue; }
+                    if replace(&mut filter[q0 as usize], true) {
+                        continue;
+                    }
                     outsides.insert(q0, left_front, right_front, w0);
-                    queue.extend(
-                        automaton.4[q0 as usize].iter().filter_map(
-                            |&(_, q1, w1)| if !filter[q1 as usize] { Some((w1 * w0, q1)) } else { None }
-                        )
-                    );
+                    queue.extend(automaton.4[q0 as usize].iter().filter_map(|&(_, q1, w1)| {
+                        if !filter[q1 as usize] {
+                            Some((w1 * w0, q1))
+                        } else {
+                            None
+                        }
+                    }));
                 }
             }
         }
@@ -180,9 +243,12 @@ impl<W: Copy + Ord + Mul<Output=W> + Zero> SxOutside<W> {
 
 #[cfg(test)]
 mod test {
-    use crate::grammars::{pmcfg::{VarT, PMCFGRule, Composition}, lcfrs::Lcfrs};
-    use log_domain::LogDomain;
     use super::*;
+    use crate::grammars::{
+        lcfrs::Lcfrs,
+        pmcfg::{Composition, PMCFGRule, VarT},
+    };
+    use log_domain::LogDomain;
 
     #[test]
     fn estimates() {
@@ -191,7 +257,10 @@ mod test {
         let w1 = LogDomain::new(0.3f64).unwrap();
         let w2 = LogDomain::new(0.7f64).unwrap();
 
-        let g = Automaton::from_grammar(gmr.rules.iter().enumerate().map(|(i, r)| (i as u32, r)), gmr.init);
+        let g = Automaton::from_grammar(
+            gmr.rules.iter().enumerate().map(|(i, r)| (i as u32, r)),
+            gmr.init,
+        );
         let inside = SxInside::from_automaton(&g, 3);
         assert_eq!(inside.get(0, 1), Some(w2));
         assert_eq!(inside.get(0, 2), Some(w1 * w2 * w2));
@@ -218,7 +287,9 @@ mod test {
                 PMCFGRule {
                     head: "S",
                     tail: vec![],
-                    composition: Composition { composition: vec![vec![VarT::T('A')]] },
+                    composition: Composition {
+                        composition: vec![vec![VarT::T('A')]],
+                    },
                     weight: LogDomain::new(0.7f64).unwrap(),
                 },
             ],

--- a/src/grammars/lcfrs/csparsing/automaton/estimates.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/estimates.rs
@@ -180,7 +180,7 @@ impl<W: Copy + Ord + Mul<Output=W> + Zero> SxOutside<W> {
 
 #[cfg(test)]
 mod test {
-    use grammars::{pmcfg::{VarT, PMCFGRule, Composition}, lcfrs::Lcfrs};
+    use crate::grammars::{pmcfg::{VarT, PMCFGRule, Composition}, lcfrs::Lcfrs};
     use log_domain::LogDomain;
     use super::*;
 

--- a/src/grammars/lcfrs/csparsing/automaton/kbest/mod.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/kbest/mod.rs
@@ -160,7 +160,7 @@ where
                 let ce2 = self.kth(m, j, rs, rk as usize).unwrap().0;
 
                 let (ob, lb, rb) = self.rules_to_brackets[rid as usize];
-                let mut additional_elements = 2 + if ob.is_ignore() { 0 } else { 2 } + if lb.is_ignore() { 0 } else { 2 };
+                let additional_elements = 2 + if ob.is_ignore() { 0 } else { 2 } + if lb.is_ignore() { 0 } else { 2 };
                 
                 let mut w1 = self.read(i, m, &ce1);
                 let w2 = self.read(m, j, &ce2);
@@ -223,7 +223,7 @@ mod test {
         extern crate flate2;
 
     pub fn example_automaton() -> Automaton<String, LogDomain<f64>> {
-        use grammars::lcfrs::Lcfrs;
+        use crate::grammars::lcfrs::Lcfrs;
         let g: Lcfrs<String, String, LogDomain<f64>>
             = "initial: [S]\n\n
                S → [[T a]] () # 0.7\n
@@ -402,7 +402,7 @@ mod test {
     }
 
     fn example_automaton2 () -> Automaton<String, LogDomain<f64>> {
-        use grammars::lcfrs::Lcfrs;
+        use crate::grammars::lcfrs::Lcfrs;
         let Lcfrs{ rules, init }: Lcfrs<String, String, LogDomain<f64>>
                     = "initial: [S]\n\n
                        S → [[Var 0 0, Var 1 0, Var 0 1, Var 1 1]] (A, B) # 1\n

--- a/src/grammars/lcfrs/csparsing/automaton/kbest/mod.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/kbest/mod.rs
@@ -1,8 +1,11 @@
-use super::{Automaton, Bracket, BracketContent, RangeT, StateT, TdBinary, TdUnary, TdNullary, TdBrackets, DenseChart, RuleIdT};
+use super::{
+    Automaton, Bracket, BracketContent, DenseChart, RangeT, RuleIdT, StateT, TdBinary, TdBrackets,
+    TdNullary, TdUnary,
+};
 use fnv::FnvHashMap;
-use unique_heap::FnvUniqueHeap;
 use num_traits::Zero;
-use std::{ ops::Mul, collections::hash_map::Entry, hash::Hash, cmp::min };
+use std::{cmp::min, collections::hash_map::Entry, hash::Hash, ops::Mul};
+use unique_heap::FnvUniqueHeap;
 
 mod backtrace;
 use self::backtrace::IndexedBacktrace;
@@ -18,19 +21,29 @@ where
     nullaries: &'a [Vec<TdNullary<W>>],
     rules_to_brackets: &'a [TdBrackets],
     rulefilter: Vec<bool>,
-    
+
     // caches already queried hyperpaths and holds the next candidates
     // for each span and state
-    d: FnvHashMap<(RangeT, RangeT, StateT), (Vec<(IndexedBacktrace<W>, W)>, FnvUniqueHeap<IndexedBacktrace<W>, W>)>,
-    
+    d: FnvHashMap<
+        (RangeT, RangeT, StateT),
+        (
+            Vec<(IndexedBacktrace<W>, W)>,
+            FnvUniqueHeap<IndexedBacktrace<W>, W>,
+        ),
+    >,
+
     // current k for root
     k: usize,
     n: usize,
-    initial: StateT
+    initial: StateT,
 }
 
 impl<'a, W: Ord> ChartIterator<'a, W> {
-    pub fn new<T: Eq + Hash>(chart: DenseChart<W>, automaton: &'a Automaton<T, W>, rulefilter: Vec<bool>) -> Self {
+    pub fn new<T: Eq + Hash>(
+        chart: DenseChart<W>,
+        automaton: &'a Automaton<T, W>,
+        rulefilter: Vec<bool>,
+    ) -> Self {
         let (n, states, beamwidth) = chart.get_meta();
         Self {
             chart,
@@ -40,28 +53,31 @@ impl<'a, W: Ord> ChartIterator<'a, W> {
             rules_to_brackets: &automaton.8,
             rulefilter,
             // we need at most `beam` entries for each span
-            d: FnvHashMap::with_capacity_and_hasher(n * (n+1) * min(states, beamwidth) / 2, Default::default()),
+            d: FnvHashMap::with_capacity_and_hasher(
+                n * (n + 1) * min(states, beamwidth) / 2,
+                Default::default(),
+            ),
             k: 0,
             n,
-            initial: automaton.7
+            initial: automaton.7,
         }
     }
 }
 
 impl<'a, W> ChartIterator<'a, W>
 where
-    W: Mul<Output=W> + Ord + Copy + Zero,
+    W: Mul<Output = W> + Ord + Copy + Zero,
 {
     /// Computes the weight of an item recursively and checks the existence of all predecessors.
     fn weight(&mut self, i: RangeT, j: RangeT, ce: &IndexedBacktrace<W>) -> Option<W> {
         use self::IndexedBacktrace::*;
-        
+
         match *ce {
             Nullary(_, weight) => Some(weight),
             Unary(_, q1, weight, index) => {
                 let w = self.kth(i, j, q1, index as usize)?.1;
                 Some(weight * w)
-            },
+            }
             Binary(_, q1, m, q2, w, index1, index2) => {
                 let w1 = self.kth(i, m, q1, index1 as usize)?.1;
                 let w2 = self.kth(m, j, q2, index2 as usize)?.1;
@@ -72,39 +88,78 @@ where
 
     /// extracts the backtraces for a spand and a constituents in a
     /// top-down approach
-    fn backtraces(chart: &DenseChart<W>, binaries: &[Vec<TdBinary<W>>], unaries: &[Vec<TdUnary<W>>], nullaries: &[Vec<TdNullary<W>>], filter: &[bool], i: RangeT, j: RangeT, q: StateT) -> FnvUniqueHeap<IndexedBacktrace<W>, W> {
+    fn backtraces(
+        chart: &DenseChart<W>,
+        binaries: &[Vec<TdBinary<W>>],
+        unaries: &[Vec<TdUnary<W>>],
+        nullaries: &[Vec<TdNullary<W>>],
+        filter: &[bool],
+        i: RangeT,
+        j: RangeT,
+        q: StateT,
+    ) -> FnvUniqueHeap<IndexedBacktrace<W>, W> {
         let mut heap = FnvUniqueHeap::default();
-        for &(r, q1, q2, w) in binaries[q as usize].iter().filter(|&(r, _, _, _)| filter[*r as usize]) {
-            for mid in (i+1)..j {
-                if let Some(sws) = chart.get_weight(i, mid, q1).and_then(|lew| chart.get_weight(mid, j, q2).map(move |riw| lew * riw)) {
-                    heap.push(IndexedBacktrace::Binary(r, q1, mid, q2, w, 0u32, 0u32), w * sws);
+        for &(r, q1, q2, w) in binaries[q as usize]
+            .iter()
+            .filter(|&(r, _, _, _)| filter[*r as usize])
+        {
+            for mid in (i + 1)..j {
+                if let Some(sws) = chart
+                    .get_weight(i, mid, q1)
+                    .and_then(|lew| chart.get_weight(mid, j, q2).map(move |riw| lew * riw))
+                {
+                    heap.push(
+                        IndexedBacktrace::Binary(r, q1, mid, q2, w, 0u32, 0u32),
+                        w * sws,
+                    );
                 }
             }
         }
-        for &(r, q1, w) in unaries[q as usize].iter().filter(|&(r, _, _)| filter[*r as usize]) {
+        for &(r, q1, w) in unaries[q as usize]
+            .iter()
+            .filter(|&(r, _, _)| filter[*r as usize])
+        {
             if let Some(w1) = chart.get_weight(i, j, q1) {
                 heap.push(IndexedBacktrace::Unary(r, q1, w, 0u32), w1 * w);
             }
         }
-        if j-i == 1 {
-            for &(r, w) in nullaries[q as usize].iter().filter(|&(r, _)| filter[*r as usize]) {
+        if j - i == 1 {
+            for &(r, w) in nullaries[q as usize]
+                .iter()
+                .filter(|&(r, _)| filter[*r as usize])
+            {
                 // is is not correct in general, but ok for terminal-seperated rules
                 heap.push(IndexedBacktrace::Nullary(r, w), w);
             }
         }
         heap
     }
-    
+
     // Implementation of the lazy enumeration for hyperpaths in Better k-best Parsing.
-    fn kth(&mut self, i: RangeT, j: RangeT, q: StateT, k: usize) -> Option<(IndexedBacktrace<W>, W)> {
+    fn kth(
+        &mut self,
+        i: RangeT,
+        j: RangeT,
+        q: StateT,
+        k: usize,
+    ) -> Option<(IndexedBacktrace<W>, W)> {
         use std::cmp::Ordering;
         // initialize structures for span and state
         // todo skip fetch if vec_len > k
         let (mut vec_len, mut last_deriv, mut last_weight) = {
-            let ChartIterator{ ref mut d, ref chart, ref binaries, ref unaries, ref nullaries, ref rulefilter, .. } = *self;
+            let ChartIterator {
+                ref mut d,
+                ref chart,
+                ref binaries,
+                ref unaries,
+                ref nullaries,
+                ref rulefilter,
+                ..
+            } = *self;
             match d.entry((i, j, q)) {
                 Entry::Vacant(ve) => {
-                    let mut bts = Self::backtraces(chart, binaries, unaries, nullaries, &rulefilter, i, j, q);
+                    let mut bts =
+                        Self::backtraces(chart, binaries, unaries, nullaries, &rulefilter, i, j, q);
                     if let Some((first, vit)) = bts.pop() {
                         let mut vec = Vec::with_capacity(bts.len() + 1);
                         vec.push((first, vit));
@@ -112,12 +167,16 @@ where
                         (1, first, vit)
                     } else {
                         ve.insert((Vec::new(), FnvUniqueHeap::default()));
-                        return None
+                        return None;
                     }
-                }, Entry::Occupied(oe) => {
+                }
+                Entry::Occupied(oe) => {
                     let &(ref d, _) = oe.get();
-                    if let Some(&(deriv, w)) = d.last() { (d.len(), deriv, w) }
-                    else { return None }
+                    if let Some(&(deriv, w)) = d.last() {
+                        (d.len(), deriv, w)
+                    } else {
+                        return None;
+                    }
                 }
             }
         };
@@ -126,16 +185,25 @@ where
             // there are at most 2 successors, so we collect them allocated in the stack
             // and at the same time to avoid getting the entry for the insertion trice
             let (wd1, wd2) = {
-                let mut worse_derivs = last_deriv.iter().filter_map(|bt| Some((bt, self.weight(i, j, &bt)?)));
+                let mut worse_derivs = last_deriv
+                    .iter()
+                    .filter_map(|bt| Some((bt, self.weight(i, j, &bt)?)));
                 (worse_derivs.next(), worse_derivs.next())
             };
 
-            let &mut (ref mut derivs, ref mut candidates) = &mut self.d.get_mut(&(i, j, q)).unwrap();
-            if let Some((bt, w)) = wd1 { candidates.push(bt, w); }
-            if let Some((bt, w)) = wd2 { candidates.push(bt, w); }
+            let &mut (ref mut derivs, ref mut candidates) =
+                &mut self.d.get_mut(&(i, j, q)).unwrap();
+            if let Some((bt, w)) = wd1 {
+                candidates.push(bt, w);
+            }
+            if let Some((bt, w)) = wd2 {
+                candidates.push(bt, w);
+            }
 
-            if candidates.is_empty() { break; }
-            
+            if candidates.is_empty() {
+                break;
+            }
+
             let last_deriv_w = candidates.pop().unwrap();
             derivs.push(last_deriv_w);
             last_deriv = last_deriv_w.0;
@@ -143,15 +211,20 @@ where
             vec_len += 1;
         }
 
-        match vec_len.cmp(&(k+1)) {
+        match vec_len.cmp(&(k + 1)) {
             Ordering::Equal => Some((last_deriv, last_weight)),
-            Ordering::Less  => None,
-            Ordering::Greater => Some(self.d[&(i, j, q)].0[k])
+            Ordering::Less => None,
+            Ordering::Greater => Some(self.d[&(i, j, q)].0[k]),
         }
     }
 
     // Reads the bracket word for a hyperpath.
-    fn read(&mut self, i: RangeT, j: RangeT, ce: &IndexedBacktrace<W>) -> Vec<Bracket<BracketContent>> {
+    fn read(
+        &mut self,
+        i: RangeT,
+        j: RangeT,
+        ce: &IndexedBacktrace<W>,
+    ) -> Vec<Bracket<BracketContent>> {
         use self::IndexedBacktrace::*;
 
         match *ce {
@@ -160,8 +233,9 @@ where
                 let ce2 = self.kth(m, j, rs, rk as usize).unwrap().0;
 
                 let (ob, lb, rb) = self.rules_to_brackets[rid as usize];
-                let additional_elements = 2 + if ob.is_ignore() { 0 } else { 2 } + if lb.is_ignore() { 0 } else { 2 };
-                
+                let additional_elements =
+                    2 + if ob.is_ignore() { 0 } else { 2 } + if lb.is_ignore() { 0 } else { 2 };
+
                 let mut w1 = self.read(i, m, &ce1);
                 let w2 = self.read(m, j, &ce2);
                 w1.reserve(w2.len() + additional_elements);
@@ -176,37 +250,38 @@ where
                     w1.insert(0, Bracket::Open(ob));
                     w1.push(Bracket::Close(ob));
                 }
-                
+
                 w1
-            },
+            }
             Unary(rid, q, _, k) => {
                 let ice = self.kth(i, j, q, k as usize).unwrap().0;
                 let mut w = self.read(i, j, &ice);
                 w.reserve(4);
                 let (ob, ib, _) = self.rules_to_brackets[rid as usize];
-                
+
                 w.insert(0, Bracket::Open(ob));
                 w.insert(1, Bracket::Open(ib));
                 w.push(Bracket::Close(ib));
                 w.push(Bracket::Close(ob));
                 w
-            },
+            }
             Nullary(rid, _) => {
                 let (ob, ib, _) = self.rules_to_brackets[rid as usize];
-                vec![ Bracket::Open(ob)
-                    , Bracket::Open(ib)
-                    , Bracket::Close(ib)
-                    , Bracket::Close(ob)
-                    ]
+                vec![
+                    Bracket::Open(ob),
+                    Bracket::Open(ib),
+                    Bracket::Close(ib),
+                    Bracket::Close(ob),
+                ]
             }
         }
     }
 }
 
-impl<'a, W: Ord + Copy + Mul<Output=W> + Zero> Iterator for ChartIterator<'a, W> {
+impl<'a, W: Ord + Copy + Mul<Output = W> + Zero> Iterator for ChartIterator<'a, W> {
     type Item = Vec<Bracket<BracketContent>>;
     fn next(&mut self) -> Option<Self::Item> {
-        let &mut ChartIterator{ initial, n, k, .. } = self;
+        let &mut ChartIterator { initial, n, k, .. } = self;
         self.k += 1;
 
         self.kth(0u8, n as u8, initial, k)
@@ -216,21 +291,25 @@ impl<'a, W: Ord + Copy + Mul<Output=W> + Zero> Iterator for ChartIterator<'a, W>
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use super::super::*;
+    use super::*;
     use log_domain::LogDomain;
-        extern crate bincode;
-        extern crate flate2;
+    extern crate bincode;
+    extern crate flate2;
 
     pub fn example_automaton() -> Automaton<String, LogDomain<f64>> {
         use crate::grammars::lcfrs::Lcfrs;
-        let g: Lcfrs<String, String, LogDomain<f64>>
-            = "initial: [S]\n\n
+        let g: Lcfrs<String, String, LogDomain<f64>> = "initial: [S]\n\n
                S → [[T a]] () # 0.7\n
-               S → [[Var 0 0]] (S) # 0.3".parse().unwrap();
-        Automaton::from_grammar(g.rules.iter().enumerate().map(|(i, r)| (i as u32, r)), g.init)
+               S → [[Var 0 0]] (S) # 0.3"
+            .parse()
+            .unwrap();
+        Automaton::from_grammar(
+            g.rules.iter().enumerate().map(|(i, r)| (i as u32, r)),
+            g.init,
+        )
     }
-    
+
     #[test]
     fn kth() {
         let zero = LogDomain::zero();
@@ -239,7 +318,8 @@ mod test {
 
         let automaton = example_automaton();
         let estimates = SxOutside::from_automaton(&automaton, 0);
-        let chart = automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &vec![true, true]);
+        let chart =
+            automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &vec![true, true]);
         let mut it = ChartIterator::new(chart, &automaton, vec![true, true]);
 
         assert_eq!(
@@ -261,7 +341,6 @@ mod test {
             it.kth(0, 1, 0, 3),
             Some((IndexedBacktrace::Unary(1, 0, w2, 2), w1 * w2 * w2 * w2))
         );
-
     }
 
     #[test]
@@ -279,11 +358,23 @@ mod test {
         assert_eq!(it.k, 0);
 
         assert!(it.next().is_some());
-        assert_eq!(it.d[&(0, 1, 0)].0, vec![(IndexedBacktrace::Nullary(0, w1), w1)]);
-        assert_eq!(it.d[&(0, 1, 0)].1.clone().into_sorted_vec(), vec![(w1 * w2, IndexedBacktrace::Unary(1, 0, w2, 0))]);
+        assert_eq!(
+            it.d[&(0, 1, 0)].0,
+            vec![(IndexedBacktrace::Nullary(0, w1), w1)]
+        );
+        assert_eq!(
+            it.d[&(0, 1, 0)].1.clone().into_sorted_vec(),
+            vec![(w1 * w2, IndexedBacktrace::Unary(1, 0, w2, 0))]
+        );
 
         assert!(it.next().is_some());
-        assert_eq!(it.d[&(0, 1, 0)].0, vec![(IndexedBacktrace::Nullary(0, w1), w1), (IndexedBacktrace::Unary(1, 0, w2, 0), w1 * w2)]);
+        assert_eq!(
+            it.d[&(0, 1, 0)].0,
+            vec![
+                (IndexedBacktrace::Nullary(0, w1), w1),
+                (IndexedBacktrace::Unary(1, 0, w2, 0), w1 * w2)
+            ]
+        );
         assert!(it.d[&(0, 1, 0)].1.is_empty());
 
         assert!(it.next().is_some());
@@ -294,14 +385,19 @@ mod test {
         let zero = LogDomain::zero();
         let automaton = example_automaton();
         let estimates = SxOutside::from_automaton(&automaton, 0);
-        let it = ChartIterator::new(automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &[true, true]), &automaton, vec![true, true]);
-        
-        assert_eq!(
-            it.take(10).count(),
-            10
+        let it = ChartIterator::new(
+            automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &[true, true]),
+            &automaton,
+            vec![true, true],
         );
 
-        let it = ChartIterator::new(automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &[true, true]), &automaton, vec![true, true]);
+        assert_eq!(it.take(10).count(), 10);
+
+        let it = ChartIterator::new(
+            automaton.fill_chart(&[String::from("a")], 1, zero, &estimates, &[true, true]),
+            &automaton,
+            vec![true, true],
+        );
         assert_eq!(
             it.take(4).collect::<Vec<_>>(),
             vec![
@@ -358,16 +454,19 @@ mod test {
     }
 
     #[test]
-    fn kth2 () {
+    fn kth2() {
         let zero = LogDomain::zero();
         let automaton = example_automaton2();
         let estimates = SxOutside::from_automaton(&automaton, 0);
         let filter = vec![true; 15];
-        let words: Vec<String> = vec!["a", "c", "b", "b", "d"].into_iter().map(|s| s.to_owned()).collect();
+        let words: Vec<String> = vec!["a", "c", "b", "b", "d"]
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect();
         let chart = automaton.fill_chart(&words, 10, zero, &estimates, &filter);
 
         assert!(chart.get_weight(0, 5, 0).is_some());
-        
+
         let mut it = ChartIterator::new(chart, &automaton, filter);
 
         for i in 1..10 {
@@ -376,35 +475,36 @@ mod test {
     }
 
     #[test]
-    fn elements2 () {
+    fn elements2() {
         let zero = LogDomain::zero();
         let automaton = example_automaton2();
         let estimates = SxOutside::from_automaton(&automaton, 0);
-        let words: Vec<String> = vec!["a", "c", "b", "b", "d"].into_iter().map(|s| s.to_owned()).collect();
+        let words: Vec<String> = vec!["a", "c", "b", "b", "d"]
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect();
         let filter = vec![true; 15];
         let chart = automaton.fill_chart(&words, 10, zero, &estimates, &filter);
 
         assert_eq!(
-            ChartIterator::new(chart, &automaton, filter.clone()).take(10).count(),
+            ChartIterator::new(chart, &automaton, filter.clone())
+                .take(10)
+                .count(),
             1
         );
 
         let chart = automaton.fill_chart(&words, 10, zero, &estimates, &filter);
         let it = ChartIterator::new(chart, &automaton, filter);
-        
+
         let some_words = it.collect::<Vec<_>>();
         let first = example_words2();
 
-        assert_eq!(
-            some_words,
-            first
-        );
+        assert_eq!(some_words, first);
     }
 
-    fn example_automaton2 () -> Automaton<String, LogDomain<f64>> {
+    fn example_automaton2() -> Automaton<String, LogDomain<f64>> {
         use crate::grammars::lcfrs::Lcfrs;
-        let Lcfrs{ rules, init }: Lcfrs<String, String, LogDomain<f64>>
-                    = "initial: [S]\n\n
+        let Lcfrs { rules, init }: Lcfrs<String, String, LogDomain<f64>> = "initial: [S]\n\n
                        S → [[Var 0 0, Var 1 0, Var 0 1, Var 1 1]] (A, B) # 1\n
                        A → [[Var 0 0, Var 1 0], [Var 0 1, Var 2 0]] (A, W, X) # 0.4\n
                        A → [[Var 0 0], [Var 1 0]] (W, X) # 0.6\n
@@ -413,79 +513,67 @@ mod test {
                        W → [[T a]] () # 1\n
                        X → [[T b]] () # 1\n
                        Y → [[T c]] () # 1\n
-                       Z → [[T d]] () # 1".parse().unwrap();
+                       Z → [[T d]] () # 1"
+            .parse()
+            .unwrap();
         Automaton::from_grammar(rules.iter().enumerate().map(|(i, r)| (i as u32, r)), init)
     }
 
-    fn example_words2 () -> Vec<Vec<Bracket<BracketContent>>> {
-        vec![
-            vec![
-                Bracket::Open(BracketContent::Component(0, 0)),
-                Bracket::Open(BracketContent::Variable(0, 0, 0)),
-                    
-                    Bracket::Open(BracketContent::Component(2, 0)),
-                    Bracket::Open(BracketContent::Variable(2, 0, 0)),
-                        Bracket::Open(BracketContent::Component(5, 0)),
-                        Bracket::Open(BracketContent::Terminal),
-                        Bracket::Close(BracketContent::Terminal),
-                        Bracket::Close(BracketContent::Component(5, 0)),
-                    Bracket::Close(BracketContent::Variable(2, 0, 0)),
-                    Bracket::Close(BracketContent::Component(2, 0)),
-
-                Bracket::Close(BracketContent::Variable(0, 0, 0)),
-                Bracket::Open(BracketContent::Variable(0, 1, 0)),
-
-                Bracket::Open(BracketContent::Component(4, 0)),
-                Bracket::Open(BracketContent::Variable(4, 0, 0)),
-                Bracket::Open(BracketContent::Component(7, 0)),
-                Bracket::Open(BracketContent::Terminal),
-                Bracket::Close(BracketContent::Terminal),
-                Bracket::Close(BracketContent::Component(7, 0)),
-                Bracket::Close(BracketContent::Variable(4, 0, 0)),
-                Bracket::Close(BracketContent::Component(4, 0)),
-
-                Bracket::Close(BracketContent::Variable(0, 1, 0)),
-                Bracket::Open(BracketContent::Variable(0, 0, 1)),
-
-                    Bracket::Open(BracketContent::Component(1, 1)),
-                    Bracket::Open(BracketContent::Variable(1, 0, 1)),
-
-                        Bracket::Open(BracketContent::Component(2, 1)),
-                        Bracket::Open(BracketContent::Variable(2, 1, 0)),
-                            Bracket::Open(BracketContent::Component(6, 0)),
-                            Bracket::Open(BracketContent::Terminal),
-                            Bracket::Close(BracketContent::Terminal),
-                            Bracket::Close(BracketContent::Component(6, 0)),
-                        Bracket::Close(BracketContent::Variable(2, 1, 0)),
-                        Bracket::Close(BracketContent::Component(2, 1)),
-
-                    Bracket::Close(BracketContent::Variable(1, 0, 1)),
-                    Bracket::Open(BracketContent::Variable(1, 2, 0)),
-
-                        Bracket::Open(BracketContent::Component(6, 0)),
-                        Bracket::Open(BracketContent::Terminal),
-                        Bracket::Close(BracketContent::Terminal),
-                        Bracket::Close(BracketContent::Component(6, 0)),
-                                 
-                    Bracket::Close(BracketContent::Variable(1, 2, 0)),
-                    Bracket::Close(BracketContent::Component(1, 1)),
-
-                Bracket::Close(BracketContent::Variable(0, 0, 1)),
-                Bracket::Open(BracketContent::Variable(0, 1, 1)),
-
-                Bracket::Open(BracketContent::Component(4, 1)),
-                Bracket::Open(BracketContent::Variable(4, 1, 0)),
-                Bracket::Open(BracketContent::Component(8, 0)),
-                Bracket::Open(BracketContent::Terminal),
-                Bracket::Close(BracketContent::Terminal),
-                Bracket::Close(BracketContent::Component(8, 0)),
-                Bracket::Close(BracketContent::Variable(4, 1, 0)),
-                Bracket::Close(BracketContent::Component(4, 1)),
-                
-                Bracket::Close(BracketContent::Variable(0, 1, 1)),
-                Bracket::Close(BracketContent::Component(0, 0)),
-            ]
-        ]
+    fn example_words2() -> Vec<Vec<Bracket<BracketContent>>> {
+        vec![vec![
+            Bracket::Open(BracketContent::Component(0, 0)),
+            Bracket::Open(BracketContent::Variable(0, 0, 0)),
+            Bracket::Open(BracketContent::Component(2, 0)),
+            Bracket::Open(BracketContent::Variable(2, 0, 0)),
+            Bracket::Open(BracketContent::Component(5, 0)),
+            Bracket::Open(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Component(5, 0)),
+            Bracket::Close(BracketContent::Variable(2, 0, 0)),
+            Bracket::Close(BracketContent::Component(2, 0)),
+            Bracket::Close(BracketContent::Variable(0, 0, 0)),
+            Bracket::Open(BracketContent::Variable(0, 1, 0)),
+            Bracket::Open(BracketContent::Component(4, 0)),
+            Bracket::Open(BracketContent::Variable(4, 0, 0)),
+            Bracket::Open(BracketContent::Component(7, 0)),
+            Bracket::Open(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Component(7, 0)),
+            Bracket::Close(BracketContent::Variable(4, 0, 0)),
+            Bracket::Close(BracketContent::Component(4, 0)),
+            Bracket::Close(BracketContent::Variable(0, 1, 0)),
+            Bracket::Open(BracketContent::Variable(0, 0, 1)),
+            Bracket::Open(BracketContent::Component(1, 1)),
+            Bracket::Open(BracketContent::Variable(1, 0, 1)),
+            Bracket::Open(BracketContent::Component(2, 1)),
+            Bracket::Open(BracketContent::Variable(2, 1, 0)),
+            Bracket::Open(BracketContent::Component(6, 0)),
+            Bracket::Open(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Component(6, 0)),
+            Bracket::Close(BracketContent::Variable(2, 1, 0)),
+            Bracket::Close(BracketContent::Component(2, 1)),
+            Bracket::Close(BracketContent::Variable(1, 0, 1)),
+            Bracket::Open(BracketContent::Variable(1, 2, 0)),
+            Bracket::Open(BracketContent::Component(6, 0)),
+            Bracket::Open(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Component(6, 0)),
+            Bracket::Close(BracketContent::Variable(1, 2, 0)),
+            Bracket::Close(BracketContent::Component(1, 1)),
+            Bracket::Close(BracketContent::Variable(0, 0, 1)),
+            Bracket::Open(BracketContent::Variable(0, 1, 1)),
+            Bracket::Open(BracketContent::Component(4, 1)),
+            Bracket::Open(BracketContent::Variable(4, 1, 0)),
+            Bracket::Open(BracketContent::Component(8, 0)),
+            Bracket::Open(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Terminal),
+            Bracket::Close(BracketContent::Component(8, 0)),
+            Bracket::Close(BracketContent::Variable(4, 1, 0)),
+            Bracket::Close(BracketContent::Component(4, 1)),
+            Bracket::Close(BracketContent::Variable(0, 1, 1)),
+            Bracket::Close(BracketContent::Component(0, 0)),
+        ]]
     }
 
     // #[test]
@@ -498,7 +586,7 @@ mod test {
     //     let csrep: CSRepresentation<String, String, LogDomain<f64>> =
     //             bincode::deserialize_from(&mut read::GzDecoder::new(csfile), bincode::Infinite)
     //                 .unwrap();
-        
+
     //     let automaton = csrep.generator;
     //     let estimate = csrep.estimates;
 

--- a/src/grammars/lcfrs/csparsing/automaton/mod.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/mod.rs
@@ -1,20 +1,23 @@
-use num_traits::One;
-use std::{collections::{BinaryHeap}, ops::Mul, mem::replace, hash::Hash, default::Default};
-use vecmultimap::VecMultiMap;
-use integeriser::{HashIntegeriser, Integeriser};
-use crate::grammars::{pmcfg::{PMCFGRule, VarT}, lcfrs::csparsing::{BracketContent, Bracket}};
+use crate::grammars::{
+    lcfrs::csparsing::{Bracket, BracketContent},
+    pmcfg::{PMCFGRule, VarT},
+};
 use crate::util::factorizable::Factorizable;
 use fnv::FnvHashMap;
+use integeriser::{HashIntegeriser, Integeriser};
+use num_traits::One;
 use num_traits::Zero;
+use std::{collections::BinaryHeap, default::Default, hash::Hash, mem::replace, ops::Mul};
+use vecmultimap::VecMultiMap;
 
 mod chart;
-mod kbest;
 mod estimates;
+mod kbest;
 mod rulemask;
 
 use self::chart::DenseChart;
-use self::kbest::ChartIterator;
 pub use self::estimates::SxOutside;
+use self::kbest::ChartIterator;
 pub use self::rulemask::RuleMaskBuilder;
 
 pub type RuleIdT = u32;
@@ -43,38 +46,44 @@ pub static NOSTATE: u32 = -1i32 as StateT;
 /// These rules are stored indexed by left rhs nonterminal (bottom-up) and
 /// lhs nonterminal (top-down).
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Automaton<T: Eq + Hash, W> (
+pub struct Automaton<T: Eq + Hash, W>(
     // rules indexed by successor nonterminals and terminals for bottom-up processing
-    Vec<Vec<(RuleIdT, StateT, BuRule<W>)>>,   // binary compatability: left state -> [(right state, action)]
-    Vec<Vec<(RuleIdT, BuRule<W>)>>,             // unary wraps: state -> [action]
-    FnvHashMap<T, Vec<(RuleIdT, BuRule<W>)>>,   // terminals: termial -> [action]
+    Vec<Vec<(RuleIdT, StateT, BuRule<W>)>>, // binary compatability: left state -> [(right state, action)]
+    Vec<Vec<(RuleIdT, BuRule<W>)>>,         // unary wraps: state -> [action]
+    FnvHashMap<T, Vec<(RuleIdT, BuRule<W>)>>, // terminals: termial -> [action]
     // rules indexed by lhs nonterminal for top-down processing
     Vec<Vec<TdBinary<W>>>,
     Vec<Vec<TdUnary<W>>>,
     Vec<Vec<TdNullary<W>>>,
     // misc data
-    Vec<Vec<(StateT, W, StateT)>>,        // mirrored binary compatability map;
-                                          // this is only used for the inside weight
-    StateT,                               // initial
-    Vec<TdBrackets>,                      // stores the brackets associated with each rule
+    Vec<Vec<(StateT, W, StateT)>>, // mirrored binary compatability map;
+    // this is only used for the inside weight
+    StateT,          // initial
+    Vec<TdBrackets>, // stores the brackets associated with each rule
 );
 
 /// intermediate representation for states:
 /// * either nonterminal with component index,
 /// * or unique state indexed by rule, component and position
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum State<Nt> { Non(Nt, usize), Unique(RuleIdT, usize, usize) }
+enum State<Nt> {
+    Non(Nt, usize),
+    Unique(RuleIdT, usize, usize),
+}
 
 impl<T: Eq + Hash, W> Automaton<T, W> {
     /// extracts an `Automaton` from a given grammar with integerized rules
-    pub fn from_grammar<'a, N>(rules: impl Iterator<Item=(RuleIdT, &'a PMCFGRule<N, T, W>)>, init: N) -> Self
+    pub fn from_grammar<'a, N>(
+        rules: impl Iterator<Item = (RuleIdT, &'a PMCFGRule<N, T, W>)>,
+        init: N,
+    ) -> Self
     where
         T: 'a + Clone,
-        W: 'a + Factorizable + Mul<Output=W> + One + Copy,
+        W: 'a + Factorizable + Mul<Output = W> + One + Copy,
         N: 'a + Hash + Eq,
     {
-        use self::State::*;
         use self::BracketContent::*;
+        use self::State::*;
 
         let mut bu_initials: FnvHashMap<T, Vec<(RuleIdT, BuRule<W>)>> = FnvHashMap::default();
         let mut bu_unaries = VecMultiMap::new();
@@ -88,7 +97,9 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
 
         for (rule_id, rule) in rules {
             let weight_factors = rule.weight.factorize(rule.composition.len());
-            for (component_id, (component, component_weight)) in rule.composition.iter().zip(weight_factors).enumerate() {
+            for (component_id, (component, component_weight)) in
+                rule.composition.iter().zip(weight_factors).enumerate()
+            {
                 let component_t = Component(rule_id as u32, component_id as u8);
                 let state_i = state_integerizer.integerise(Non(&rule.head, component_id)) as StateT;
 
@@ -96,25 +107,47 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
                 if component.len() == 1 {
                     match component[0] {
                         VarT::T(ref t) => {
-                            bu_initials.entry(t.clone()).or_default().push((rule_to_brackets.len() as RuleIdT, (component_weight, state_i)));
-                            td_initials.push_to(state_i as usize, (rule_to_brackets.len() as RuleIdT, component_weight));
+                            bu_initials.entry(t.clone()).or_default().push((
+                                rule_to_brackets.len() as RuleIdT,
+                                (component_weight, state_i),
+                            ));
+                            td_initials.push_to(
+                                state_i as usize,
+                                (rule_to_brackets.len() as RuleIdT, component_weight),
+                            );
                             rule_to_brackets.push((component_t, Terminal, Ignore));
-                        },
+                        }
                         VarT::Var(i, j) => {
                             let variable_t = Variable(rule_id as u32, i as u8, j as u8);
-                            let successor_state_i = state_integerizer.integerise(Non(&rule.tail[i], j)) as StateT;
-                            bu_unaries.push_to(successor_state_i as usize, (rule_to_brackets.len() as RuleIdT, (component_weight, state_i)));
-                            td_unaries.push_to(state_i as usize, (rule_to_brackets.len() as RuleIdT, successor_state_i, component_weight));
+                            let successor_state_i =
+                                state_integerizer.integerise(Non(&rule.tail[i], j)) as StateT;
+                            bu_unaries.push_to(
+                                successor_state_i as usize,
+                                (
+                                    rule_to_brackets.len() as RuleIdT,
+                                    (component_weight, state_i),
+                                ),
+                            );
+                            td_unaries.push_to(
+                                state_i as usize,
+                                (
+                                    rule_to_brackets.len() as RuleIdT,
+                                    successor_state_i,
+                                    component_weight,
+                                ),
+                            );
                             rule_to_brackets.push((component_t, variable_t, Ignore));
                         }
                     }
-                }   // handle rules with multiple nonnterminals
+                }
+                // handle rules with multiple nonnterminals
                 else {
                     let v1 = component[0].unwrap_var();
                     let v2 = component[1].unwrap_var();
-                    let successors = ( state_integerizer.integerise(Non(&rule.tail[v1.0], v1.1)) as StateT
-                                     , state_integerizer.integerise(Non(&rule.tail[v2.0], v2.1)) as StateT
-                                     );
+                    let successors = (
+                        state_integerizer.integerise(Non(&rule.tail[v1.0], v1.1)) as StateT,
+                        state_integerizer.integerise(Non(&rule.tail[v2.0], v2.1)) as StateT,
+                    );
                     let vt1 = Variable(rule_id as u32, v1.0 as u8, v1.1 as u8);
                     let vt2 = Variable(rule_id as u32, v2.0 as u8, v2.1 as u8);
                     // set lhs nontermal as target state or create unique
@@ -122,26 +155,65 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
                     let (mut targetstate, mut outer_t) = if component.len() == 2 {
                         (state_i, component_t)
                     } else {
-                        (state_integerizer.integerise(Unique(rule_id, component_id, 0)) as StateT, Ignore)
-                    };  
-                    bu_binaries.push_to(successors.0 as usize, (rule_to_brackets.len() as RuleIdT, successors.1, (component_weight, targetstate)));
-                    td_binaries.push_to(targetstate as usize, (rule_to_brackets.len() as RuleIdT, successors.0, successors.1, component_weight));
+                        (
+                            state_integerizer.integerise(Unique(rule_id, component_id, 0))
+                                as StateT,
+                            Ignore,
+                        )
+                    };
+                    bu_binaries.push_to(
+                        successors.0 as usize,
+                        (
+                            rule_to_brackets.len() as RuleIdT,
+                            successors.1,
+                            (component_weight, targetstate),
+                        ),
+                    );
+                    td_binaries.push_to(
+                        targetstate as usize,
+                        (
+                            rule_to_brackets.len() as RuleIdT,
+                            successors.0,
+                            successors.1,
+                            component_weight,
+                        ),
+                    );
                     rule_to_brackets.push((outer_t, vt1, vt2));
                     // continue for the remaining nonterminals in the same manner
-                    for succ_offset in 1..=(component.len()-2) {
+                    for succ_offset in 1..=(component.len() - 2) {
                         let l_successor = targetstate;
-                        let v = component[1+succ_offset].unwrap_var();
+                        let v = component[1 + succ_offset].unwrap_var();
                         let vt = Variable(rule_id as u32, v.0 as u8, v.1 as u8);
-                        let r_successor = state_integerizer.integerise(Non(&rule.tail[v.0], v.1)) as StateT;
-                        if component.len() == 2+succ_offset { 
+                        let r_successor =
+                            state_integerizer.integerise(Non(&rule.tail[v.0], v.1)) as StateT;
+                        if component.len() == 2 + succ_offset {
                             targetstate = state_i;
                             outer_t = component_t;
                         } else {
-                            targetstate = state_integerizer.integerise(Unique(rule_id, component_id, succ_offset)) as StateT;
+                            targetstate = state_integerizer.integerise(Unique(
+                                rule_id,
+                                component_id,
+                                succ_offset,
+                            )) as StateT;
                             outer_t = Ignore;
                         };
-                        bu_binaries.push_to(l_successor as usize, (rule_to_brackets.len() as RuleIdT, r_successor, (W::one(), targetstate)));
-                        td_binaries.push_to(targetstate as usize, (rule_to_brackets.len() as RuleIdT, l_successor, r_successor, W::one()));
+                        bu_binaries.push_to(
+                            l_successor as usize,
+                            (
+                                rule_to_brackets.len() as RuleIdT,
+                                r_successor,
+                                (W::one(), targetstate),
+                            ),
+                        );
+                        td_binaries.push_to(
+                            targetstate as usize,
+                            (
+                                rule_to_brackets.len() as RuleIdT,
+                                l_successor,
+                                r_successor,
+                                W::one(),
+                            ),
+                        );
                         rule_to_brackets.push((outer_t, Ignore, vt));
                     }
                 }
@@ -150,7 +222,11 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
 
         let binaries = bu_binaries.into_vec_with_size(state_integerizer.size());
         let mut binaries_mirrorred = VecMultiMap::new();
-        for (ql, qr, w, q0) in binaries.iter().enumerate().flat_map(|(ql, v)| v.iter().map(move |&(_, qr, (w, q0))| (ql, qr, w, q0))) {
+        for (ql, qr, w, q0) in binaries
+            .iter()
+            .enumerate()
+            .flat_map(|(ql, v)| v.iter().map(move |&(_, qr, (w, q0))| (ql, qr, w, q0)))
+        {
             binaries_mirrorred.push_to(qr as usize, (ql as StateT, w, q0));
         }
         Automaton(
@@ -162,15 +238,22 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
             td_initials.into_vec_with_size(state_integerizer.size()),
             binaries_mirrorred.into_vec_with_size(state_integerizer.size()),
             state_integerizer.integerise(Non(&init, 0)) as StateT,
-            rule_to_brackets
+            rule_to_brackets,
         )
     }
 
     /// Create an Iteator for well bracketed words in the  language of the
     /// context-free approximation
-    pub fn generate<'a>(&'a self, word: &[T], beam: usize, delta: W, estimates: &SxOutside<W>, rulefilter: Vec<bool>) -> ChartIterator<'a, W>
+    pub fn generate<'a>(
+        &'a self,
+        word: &[T],
+        beam: usize,
+        delta: W,
+        estimates: &SxOutside<W>,
+        rulefilter: Vec<bool>,
+    ) -> ChartIterator<'a, W>
     where
-        W: Ord + Copy + Mul<Output=W> + Zero + One,
+        W: Ord + Copy + Mul<Output = W> + Zero + One,
     {
         let chart = self.fill_chart(word, beam, delta, estimates, &rulefilter);
         ChartIterator::new(chart, self, rulefilter)
@@ -181,9 +264,16 @@ impl<T: Eq + Hash, W> Automaton<T, W> {
     }
 }
 
-impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
+impl<T: Eq + Hash, W: Ord + Mul<Output = W> + Copy + Zero + One> Automaton<T, W> {
     /// implements the CKY algorithm with chain rules
-    pub fn fill_chart(&self, word: &[T], beam: usize, delta: W, outsides: &SxOutside<W>, rule_filter: &[bool]) -> DenseChart<W> {
+    pub fn fill_chart(
+        &self,
+        word: &[T],
+        beam: usize,
+        delta: W,
+        outsides: &SxOutside<W>,
+        rule_filter: &[bool],
+    ) -> DenseChart<W> {
         let n = word.len();
         let nonterminals = self.0.len();
 
@@ -192,7 +282,7 @@ impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
         let mut chart = DenseChart::new(n, nonterminals, beam);
 
         for range in 1..=n {
-            for l in 0..=(n-range) {
+            for l in 0..=(n - range) {
                 let r = l + range;
 
                 heap_of_nonterminals.clear();
@@ -200,29 +290,34 @@ impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
                 // initial predictions for each position in word
                 if range == 1 {
                     if let Some(initials) = self.2.get(&word[l]) {
-                        heap_of_nonterminals.extend(initials.iter().filter_map(
-                            |&(rid, (w, q))| {
-                                if !rule_filter[rid as usize] { return None; }
-                                let _ = outsides.get(q, l, r, n)?;
-                                Some((w, q))
+                        heap_of_nonterminals.extend(initials.iter().filter_map(|&(rid, (w, q))| {
+                            if !rule_filter[rid as usize] {
+                                return None;
                             }
-                        ))
+                            let _ = outsides.get(q, l, r, n)?;
+                            Some((w, q))
+                        }))
                     }
                 }
-                
+
                 // binary step
-                for mid in l+1..r {
+                for mid in l + 1..r {
                     for &(lnt, lew) in chart.iterate_nont(l as u8, mid as u8) {
                         let available_rules = &self.0[lnt as usize];
                         let cache = (NOSTATE, None);
                         heap_of_nonterminals.extend(available_rules.iter().filter_map(
                             |&(rid, rnt, (ruw, lhs))| {
-                                if !rule_filter[rid as usize] { return None; }
-                                let riw = if cache.0 == rnt { cache.1 }
-                                          else { chart.get_weight(mid as u8, r as u8, rnt) }?;
+                                if !rule_filter[rid as usize] {
+                                    return None;
+                                }
+                                let riw = if cache.0 == rnt {
+                                    cache.1
+                                } else {
+                                    chart.get_weight(mid as u8, r as u8, rnt)
+                                }?;
                                 let _ = outsides.get(lhs, l, r, n)?;
                                 Some((lew * ruw * riw, lhs))
-                            }
+                            },
                         ));
                     }
                 }
@@ -230,19 +325,26 @@ impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
                 // unary step and insertion into chart
                 let mut skip = vec![false; self.0.len()];
                 let mut i = beam;
-                let worst_weight = delta * heap_of_nonterminals.peek().map_or(W::zero(), |&(w, _)| w);
+                let worst_weight =
+                    delta * heap_of_nonterminals.peek().map_or(W::zero(), |&(w, _)| w);
                 while let Some((w, q)) = heap_of_nonterminals.pop() {
-                    if replace(&mut skip[q as usize], true) { continue; }
+                    if replace(&mut skip[q as usize], true) {
+                        continue;
+                    }
                     chart.add_entry(l as u8, r as u8, q, w);
                     heap_of_nonterminals.extend(self.1[q as usize].iter().filter_map(
                         |&(rid, (rw, q))| {
-                            if !rule_filter[rid as usize] { return None; }
+                            if !rule_filter[rid as usize] {
+                                return None;
+                            }
                             let _ = outsides.get(q, l, r, n)?;
                             Some((rw * w, q))
-                        }
+                        },
                     ));
                     i -= 1;
-                    if i == 0 || w < worst_weight { break; }
+                    if i == 0 || w < worst_weight {
+                        break;
+                    }
                 }
             }
         }

--- a/src/grammars/lcfrs/csparsing/automaton/mod.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/mod.rs
@@ -2,8 +2,8 @@ use num_traits::One;
 use std::{collections::{BinaryHeap}, ops::Mul, mem::replace, hash::Hash, default::Default};
 use vecmultimap::VecMultiMap;
 use integeriser::{HashIntegeriser, Integeriser};
-use grammars::{pmcfg::{PMCFGRule, VarT}, lcfrs::csparsing::{BracketContent, Bracket}};
-use util::factorizable::Factorizable;
+use crate::grammars::{pmcfg::{PMCFGRule, VarT}, lcfrs::csparsing::{BracketContent, Bracket}};
+use crate::util::factorizable::Factorizable;
 use fnv::FnvHashMap;
 use num_traits::Zero;
 
@@ -214,7 +214,7 @@ impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
                 for mid in l+1..r {
                     for &(lnt, lew) in chart.iterate_nont(l as u8, mid as u8) {
                         let available_rules = &self.0[lnt as usize];
-                        let mut cache = (NOSTATE, None);
+                        let cache = (NOSTATE, None);
                         heap_of_nonterminals.extend(available_rules.iter().filter_map(
                             |&(rid, rnt, (ruw, lhs))| {
                                 if !rule_filter[rid as usize] { return None; }
@@ -230,7 +230,7 @@ impl<T: Eq + Hash, W: Ord + Mul<Output=W> + Copy + Zero + One> Automaton<T, W> {
                 // unary step and insertion into chart
                 let mut skip = vec![false; self.0.len()];
                 let mut i = beam;
-                let mut worst_weight = delta * heap_of_nonterminals.peek().map_or(W::zero(), |&(w, _)| w);
+                let worst_weight = delta * heap_of_nonterminals.peek().map_or(W::zero(), |&(w, _)| w);
                 while let Some((w, q)) = heap_of_nonterminals.pop() {
                     if replace(&mut skip[q as usize], true) { continue; }
                     chart.add_entry(l as u8, r as u8, q, w);

--- a/src/grammars/lcfrs/csparsing/automaton/rulemask.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/rulemask.rs
@@ -1,11 +1,11 @@
-use super::{StateT, RuleIdT};
+use super::{RuleIdT, StateT};
 
 use crate::grammars::pmcfg::PMCFGRule;
 
-use std::{ hash::Hash, collections::HashSet };
-use integeriser::{HashIntegeriser, Integeriser};
 use fnv::FnvHashMap;
+use integeriser::{HashIntegeriser, Integeriser};
 use std::cmp::max;
+use std::{collections::HashSet, hash::Hash};
 
 use vecmultimap::VecMultiMap;
 
@@ -13,25 +13,28 @@ use vecmultimap::VecMultiMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleMaskBuilder<T>
 where
-    T: Eq + Hash
+    T: Eq + Hash,
 {
     initial_nt: StateT,
     terminal: FnvHashMap<T, Vec<StateT>>,
-    inner: Vec<Vec<(Vec<StateT>, StateT)>>,             // Save some storage using binary rules
+    inner: Vec<Vec<(Vec<StateT>, StateT)>>, // Save some storage using binary rules
     td_inner: Vec<Vec<(Vec<RuleIdT>, Vec<StateT>)>>,
     ruleids: usize,
-    states: usize
+    states: usize,
 }
 
 impl<T> RuleMaskBuilder<T>
 where
     T: Clone + Eq + Hash,
 {
-    pub fn new<'a, N, W>(rules: impl Iterator<Item=&'a PMCFGRule<N, T, W>> + 'a, initial: &N) -> Self 
+    pub fn new<'a, N, W>(
+        rules: impl Iterator<Item = &'a PMCFGRule<N, T, W>> + 'a,
+        initial: &N,
+    ) -> Self
     where
         N: Eq + Hash + 'a,
         T: 'a,
-        W: 'a
+        W: 'a,
     {
         let mut rid_counter: StateT = 0;
 
@@ -45,26 +48,38 @@ where
 
             if rule.composition.len() == 1
                 && rule.composition.composition[0].len() == 1
-                && rule.composition.composition[0][0].is_t() {
-                    terminal.entry(rule.composition.composition[0][0].unwrap_t().clone())
-                            .or_default()
-                            .push(nid);
-                    inner_td.push_to(nid as usize, (vec![rid_counter], vec![]));
-                    rid_counter += 1;
+                && rule.composition.composition[0][0].is_t()
+            {
+                terminal
+                    .entry(rule.composition.composition[0][0].unwrap_t().clone())
+                    .or_default()
+                    .push(nid);
+                inner_td.push_to(nid as usize, (vec![rid_counter], vec![]));
+                rid_counter += 1;
             } else {
-                let rids = rule.composition.iter().flat_map(
-                    |component| {
+                let rids = rule
+                    .composition
+                    .iter()
+                    .flat_map(|component| {
                         let new_rids = max(component.len() - 1, 1) as RuleIdT;
                         rid_counter += new_rids;
                         ((rid_counter - new_rids)..rid_counter)
-                    }
-                ).collect::<Vec<_>>();
+                    })
+                    .collect::<Vec<_>>();
 
-                let i_rhs = rule.tail.iter().map(|i| integeriser.integerise(i) as StateT)
-                        .collect::<HashSet<_>>().into_iter().collect::<Vec<_>>();
+                let i_rhs = rule
+                    .tail
+                    .iter()
+                    .map(|i| integeriser.integerise(i) as StateT)
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
                 for rhs_index in 0..(i_rhs.len()) {
                     let mut rhs_remainder = i_rhs.clone();
-                    inner.push_to(rhs_remainder.remove(rhs_index) as usize, (rhs_remainder, nid));
+                    inner.push_to(
+                        rhs_remainder.remove(rhs_index) as usize,
+                        (rhs_remainder, nid),
+                    );
                 }
                 inner_td.push_to(nid as usize, (rids, i_rhs));
             }
@@ -78,7 +93,7 @@ where
             inner: inner.into_vec_with_size(integeriser.size()),
             td_inner: inner_td.into_vec_with_size(integeriser.size()),
             ruleids: rid_counter as usize,
-            states: integeriser.size()
+            states: integeriser.size(),
         }
     }
 
@@ -99,13 +114,19 @@ where
         }
 
         while let Some(nt) = runtime_stack.pop() {
-            if replace(&mut productive_nts[nt as usize], true) { continue; }
+            if replace(&mut productive_nts[nt as usize], true) {
+                continue;
+            }
             runtime_stack.extend(self.inner[nt as usize].iter().filter_map(
                 |&(ref other_nts, top)| {
-                    if !productive_nts[top as usize] && other_nts.iter().all(|nt| productive_nts[*nt as usize]) {
+                    if !productive_nts[top as usize]
+                        && other_nts.iter().all(|nt| productive_nts[*nt as usize])
+                    {
                         Some(top)
-                    } else { None }
-                }
+                    } else {
+                        None
+                    }
+                },
             ));
         }
 
@@ -113,15 +134,19 @@ where
 
         runtime_stack.push(self.initial_nt);
         while let Some(nt) = runtime_stack.pop() {
-            if replace(&mut reachable_nts[nt as usize], true) || !productive_nts[nt as usize] { continue; }
+            if replace(&mut reachable_nts[nt as usize], true) || !productive_nts[nt as usize] {
+                continue;
+            }
             for &(ref ruleids, ref bottom_states) in &self.td_inner[nt as usize] {
                 if bottom_states.iter().all(|nt| productive_nts[*nt as usize]) {
-                    for rule_id in ruleids { productive_and_reachable_rules[*rule_id as usize] = true; }
+                    for rule_id in ruleids {
+                        productive_and_reachable_rules[*rule_id as usize] = true;
+                    }
                     runtime_stack.extend(bottom_states);
                 }
             }
         }
-        
+
         productive_and_reachable_rules
     }
 }
@@ -131,24 +156,77 @@ mod test {
     use super::*;
     use crate::grammars::pmcfg::{Composition, VarT};
 
-    fn hots<I: IntoIterator<Item=usize>>(is: I, len: usize) -> Vec<bool> {
+    fn hots<I: IntoIterator<Item = usize>>(is: I, len: usize) -> Vec<bool> {
         let mut v = vec![false; len];
-        for i in is { v[i] = true; }
+        for i in is {
+            v[i] = true;
+        }
         v
     }
 
     #[test]
     fn filter() {
         let rules = vec![
-            PMCFGRule{ head: "A", tail: vec!["A", "T1", "T2"], weight: 1f64, composition: Composition::from(vec![vec![VarT::Var(1, 0), VarT::Var(0,0)], vec![VarT::Var(0, 1), VarT::Var(2, 0)]])},
-            PMCFGRule{ head: "A", tail: vec!["B"], weight: 1f64, composition: Composition::from(vec![vec![VarT::Var(1, 0), VarT::Var(0,0)], vec![VarT::Var(0, 1), VarT::Var(2, 0)]])},
-            PMCFGRule{ head: "A", tail: vec!["T0", "T0"], weight: 1f64, composition: Composition::from(vec![vec![VarT::Var(0,0)], vec![VarT::Var(1,0)]])},
-            PMCFGRule{ head: "B", tail: vec!["T3", "T3"], weight: 1f64, composition: Composition::from(vec![vec![VarT::Var(0,0)], vec![VarT::Var(1,0)]])},
-            PMCFGRule{ head: "C", tail: vec!["T3", "T3"], weight: 1f64, composition: Composition::from(vec![vec![VarT::Var(0,0)], vec![VarT::Var(1,0)]])},
-            PMCFGRule{ head: "T0", tail: vec![], weight: 1f64, composition: Composition::from(vec![vec![VarT::T(0)]])},
-            PMCFGRule{ head: "T1", tail: vec![], weight: 1f64, composition: Composition::from(vec![vec![VarT::T(1)]])},
-            PMCFGRule{ head: "T2", tail: vec![], weight: 1f64, composition: Composition::from(vec![vec![VarT::T(2)]])},
-            PMCFGRule{ head: "T3", tail: vec![], weight: 1f64, composition: Composition::from(vec![vec![VarT::T(3)]])},
+            PMCFGRule {
+                head: "A",
+                tail: vec!["A", "T1", "T2"],
+                weight: 1f64,
+                composition: Composition::from(vec![
+                    vec![VarT::Var(1, 0), VarT::Var(0, 0)],
+                    vec![VarT::Var(0, 1), VarT::Var(2, 0)],
+                ]),
+            },
+            PMCFGRule {
+                head: "A",
+                tail: vec!["B"],
+                weight: 1f64,
+                composition: Composition::from(vec![
+                    vec![VarT::Var(1, 0), VarT::Var(0, 0)],
+                    vec![VarT::Var(0, 1), VarT::Var(2, 0)],
+                ]),
+            },
+            PMCFGRule {
+                head: "A",
+                tail: vec!["T0", "T0"],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::Var(0, 0)], vec![VarT::Var(1, 0)]]),
+            },
+            PMCFGRule {
+                head: "B",
+                tail: vec!["T3", "T3"],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::Var(0, 0)], vec![VarT::Var(1, 0)]]),
+            },
+            PMCFGRule {
+                head: "C",
+                tail: vec!["T3", "T3"],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::Var(0, 0)], vec![VarT::Var(1, 0)]]),
+            },
+            PMCFGRule {
+                head: "T0",
+                tail: vec![],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::T(0)]]),
+            },
+            PMCFGRule {
+                head: "T1",
+                tail: vec![],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::T(1)]]),
+            },
+            PMCFGRule {
+                head: "T2",
+                tail: vec![],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::T(2)]]),
+            },
+            PMCFGRule {
+                head: "T3",
+                tail: vec![],
+                weight: 1f64,
+                composition: Composition::from(vec![vec![VarT::T(3)]]),
+            },
         ];
 
         let filter = RuleMaskBuilder::new(rules.iter(), &"A");
@@ -157,9 +235,18 @@ mod test {
         assert_eq!(filter.build(&[1]), vec![false; 14]);
         assert_eq!(filter.build(&[2]), vec![false; 14]);
         assert_eq!(filter.build(&[1, 2]), vec![false; 14]);
-        assert_eq!(filter.build(&[0, 1]), hots(vec![4,5,10], 14));
-        assert_eq!(filter.build(&[0, 1, 2]), hots(vec![0,1,4,5,10,11,12], 14));
-        assert_eq!(filter.build(&[1, 2, 3]), hots(vec![0,1,2,3,6,7,11,12,13], 14));
-        assert_eq!(filter.build(&[0, 1, 2, 3]), hots(vec![0,1,2,3,4,5,6,7,10,11,12,13], 14));
+        assert_eq!(filter.build(&[0, 1]), hots(vec![4, 5, 10], 14));
+        assert_eq!(
+            filter.build(&[0, 1, 2]),
+            hots(vec![0, 1, 4, 5, 10, 11, 12], 14)
+        );
+        assert_eq!(
+            filter.build(&[1, 2, 3]),
+            hots(vec![0, 1, 2, 3, 6, 7, 11, 12, 13], 14)
+        );
+        assert_eq!(
+            filter.build(&[0, 1, 2, 3]),
+            hots(vec![0, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13], 14)
+        );
     }
 }

--- a/src/grammars/lcfrs/csparsing/automaton/rulemask.rs
+++ b/src/grammars/lcfrs/csparsing/automaton/rulemask.rs
@@ -1,6 +1,6 @@
 use super::{StateT, RuleIdT};
 
-use grammars::pmcfg::PMCFGRule;
+use crate::grammars::pmcfg::PMCFGRule;
 
 use std::{ hash::Hash, collections::HashSet };
 use integeriser::{HashIntegeriser, Integeriser};
@@ -129,7 +129,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use grammars::pmcfg::{Composition, VarT};
+    use crate::grammars::pmcfg::{Composition, VarT};
 
     fn hots<I: IntoIterator<Item=usize>>(is: I, len: usize) -> Vec<bool> {
         let mut v = vec![false; len];

--- a/src/grammars/lcfrs/csparsing/fallback.rs
+++ b/src/grammars/lcfrs/csparsing/fallback.rs
@@ -1,8 +1,8 @@
 use super::*;
-use grammars::pmcfg::{PMCFGRule, VarT, Composition};
-use util::{tree::GornTree, IntMap };
+use crate::grammars::pmcfg::{PMCFGRule, VarT, Composition};
+use crate::util::{tree::GornTree, IntMap };
 use std::collections::{BTreeSet, BTreeMap};
-use dyck::Bracket;
+use crate::dyck::Bracket;
 use fnv::{FnvHashMap, FnvHashSet};
 use vecmultimap::VecMultiMapAdapter;
 

--- a/src/grammars/lcfrs/csparsing/mod.rs
+++ b/src/grammars/lcfrs/csparsing/mod.rs
@@ -1,16 +1,21 @@
-mod fallback;
 mod automaton;
+mod fallback;
 
 use super::Lcfrs;
 
 use crate::dyck::Bracket;
 use crate::grammars::pmcfg::PMCFGRule;
-use crate::util::{ tree::GornTree, factorizable::Factorizable };
-use std::{ collections::{BTreeMap}, fmt::{Display, Error, Formatter}, hash::Hash, ops::Mul };
-use num_traits::{Zero, One};
-use std::time::{Instant, Duration};
+use crate::util::{factorizable::Factorizable, tree::GornTree};
+use num_traits::{One, Zero};
+use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Error, Formatter},
+    hash::Hash,
+    ops::Mul,
+};
 
-use self::automaton::{Automaton, SxOutside, RuleMaskBuilder};
+use self::automaton::{Automaton, RuleMaskBuilder, SxOutside};
 
 /// The indices of a bracket in a CS representation for an lcfrs.
 /// Assumes integerized an itergerized set of (at most 2^32) rules and fanouts
@@ -31,7 +36,7 @@ impl BracketContent {
     pub fn is_ignore(self) -> bool {
         match self {
             BracketContent::Ignore => true,
-            _ => false
+            _ => false,
         }
     }
 }
@@ -44,7 +49,7 @@ impl Display for BracketContent {
             BracketContent::Component(rule_id, comp_id) => write!(f, "_{}^{}", rule_id, comp_id),
             BracketContent::Variable(rule_id, i, j) => write!(f, "_{{{},{}}}^{}", rule_id, i, j),
             BracketContent::Terminal => write!(f, "_{{TERM}}"),
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 }
@@ -72,65 +77,116 @@ pub struct GeneratorBuilder<'a, N, T: Eq + Hash, W> {
 impl<'a, N, T, W> GeneratorBuilder<'a, N, T, W>
 where
     T: Eq + Hash + Clone,
-    W: Zero + Ord + Copy + One + Mul<Output=W>,
-    N: Clone
+    W: Zero + Ord + Copy + One + Mul<Output = W>,
+    N: Clone,
 {
-    pub fn set_candidates(&mut self, c: usize) { self.candidates = Some(c); }
-    pub fn set_beam(&mut self, b: usize) { self.beam = Some(b); }
-    pub fn set_delta(&mut self, d: W) { self.delta = d; }
-    pub fn allow_root_prediction(&mut self) { self.root_prediction = true; }
+    pub fn set_candidates(&mut self, c: usize) {
+        self.candidates = Some(c);
+    }
+    pub fn set_beam(&mut self, b: usize) {
+        self.beam = Some(b);
+    }
+    pub fn set_delta(&mut self, d: W) {
+        self.delta = d;
+    }
+    pub fn allow_root_prediction(&mut self) {
+        self.root_prediction = true;
+    }
 
-    pub fn with_fallback(&self, word: &[T]) -> (impl Iterator<Item=GornTree<&'a PMCFGRule<N, T, W>>> + 'a, Option<GornTree<PMCFGRule<N, T, W>>>) {
-        let &Self { grammar, mut candidates, beam, delta, .. } = self;
+    pub fn with_fallback(
+        &self,
+        word: &[T],
+    ) -> (
+        impl Iterator<Item = GornTree<&'a PMCFGRule<N, T, W>>> + 'a,
+        Option<GornTree<PMCFGRule<N, T, W>>>,
+    ) {
+        let &Self {
+            grammar,
+            mut candidates,
+            beam,
+            delta,
+            ..
+        } = self;
         let realbeam = beam.unwrap_or(grammar.generator.states());
         let rulemask = grammar.rulemaskbuilder.build(word);
-        let mut word_iterator = grammar.generator.generate(word, realbeam, delta, &grammar.estimates, rulemask).peekable();
-        let first = word_iterator.peek().map(|w| fallback::FailedParseTree::new(w).merge(&grammar.rules));
+        let mut word_iterator = grammar
+            .generator
+            .generate(word, realbeam, delta, &grammar.estimates, rulemask)
+            .peekable();
+        let first = word_iterator
+            .peek()
+            .map(|w| fallback::FailedParseTree::new(w).merge(&grammar.rules));
 
         let count_candidates = move |_: &Vec<Delta>| -> bool {
-            candidates.as_mut().map_or(true, |c| if *c == 0 { false } else { *c -= 1; true } )
+            candidates.as_mut().map_or(true, |c| {
+                if *c == 0 {
+                    false
+                } else {
+                    *c -= 1;
+                    true
+                }
+            })
         };
-        
-        ( word_iterator.take_while(count_candidates).filter_map(move |bs| grammar.toderiv(&bs))
-        , first
+
+        (
+            word_iterator
+                .take_while(count_candidates)
+                .filter_map(move |bs| grammar.toderiv(&bs)),
+            first,
         )
     }
 
     pub fn debug(&self, word: &[T]) -> (usize, usize, Duration, DebugResult<N, T, W>) {
         let starting_time = Instant::now();
-        let &Self { grammar, mut candidates, beam, delta, .. } = self;
+        let &Self {
+            grammar,
+            mut candidates,
+            beam,
+            delta,
+            ..
+        } = self;
         let rulemask = grammar.rulemaskbuilder.build(word);
         let realbeam = beam.unwrap_or(grammar.generator.states());
         let count_candidates = move |_: &Vec<Delta>| -> bool {
-            candidates.as_mut().map_or(true, |c| if *c == 0 { false } else { *c -= 1; true } )
+            candidates.as_mut().map_or(true, |c| {
+                if *c == 0 {
+                    false
+                } else {
+                    *c -= 1;
+                    true
+                }
+            })
         };
-        let word_iterator = grammar.generator.generate(word, realbeam, delta, &grammar.estimates, rulemask);
+        let word_iterator =
+            grammar
+                .generator
+                .generate(word, realbeam, delta, &grammar.estimates, rulemask);
         let mut word_iterator = word_iterator.take_while(count_candidates).peekable();
 
         let mut enumerated_words = 0;
 
         let o_fallback_word = word_iterator.peek().cloned();
-        let o_parse_tree = word_iterator.filter_map(
-            |cfg_deriv| {
+        let o_parse_tree = word_iterator
+            .filter_map(|cfg_deriv| {
                 enumerated_words += 1;
                 grammar.toderiv(&cfg_deriv)
-            }).next();
-        
+            })
+            .next();
+
         let debug_result = match (o_parse_tree, o_fallback_word) {
-                (Some(t), _)
-                    => DebugResult::Parse(t.cloned(), enumerated_words),
-                (None, Some(w)) => {
-                    let tree = fallback::FailedParseTree::new(&w).merge(&grammar.rules);
-                    DebugResult::Fallback(tree, enumerated_words)
-                },
-                (None, None)
-                    => DebugResult::Noparse
+            (Some(t), _) => DebugResult::Parse(t.cloned(), enumerated_words),
+            (None, Some(w)) => {
+                let tree = fallback::FailedParseTree::new(&w).merge(&grammar.rules);
+                DebugResult::Fallback(tree, enumerated_words)
+            }
+            (None, None) => DebugResult::Noparse,
         };
-        
-        ( grammar.rules.len()
-        , word.len()
-        , starting_time.elapsed()
-        , debug_result
+
+        (
+            grammar.rules.len(),
+            word.len(),
+            starting_time.elapsed(),
+            debug_result,
         )
     }
 }
@@ -138,13 +194,13 @@ where
 pub enum DebugResult<N, T, W> {
     Parse(GornTree<PMCFGRule<N, T, W>>, usize),
     Fallback(GornTree<PMCFGRule<N, T, W>>, usize),
-    Noparse
-} 
+    Noparse,
+}
 
 impl<N, T, W> CSRepresentation<N, T, W>
 where
     T: Ord + Hash + Clone,
-    W: Ord + Copy + One + Mul<Output=W>,
+    W: Ord + Copy + One + Mul<Output = W>,
     N: Clone,
 {
     /// Instantiates a CS representation for an `LCFRS`.
@@ -152,7 +208,7 @@ where
     where
         M: Into<Lcfrs<N, T, W>>,
         W: Factorizable + Zero,
-        N: Hash + Eq
+        N: Hash + Eq,
     {
         assert!(estimates_max_width <= u8::max_value() as usize);
         let (rules, initial) = grammar.into().destruct();
@@ -162,25 +218,33 @@ where
         };
         let rulemaskbuilder = RuleMaskBuilder::new(rules.iter(), &initial);
         let estimates = SxOutside::from_automaton(&generator, estimates_max_width as u8);
-        
-        CSRepresentation { generator, rulemaskbuilder, estimates, rules }
+
+        CSRepresentation {
+            generator,
+            rulemaskbuilder,
+            estimates,
+            rules,
+        }
     }
 
     pub fn build_generator<'a>(&'a self) -> GeneratorBuilder<'a, N, T, W>
     where
-        W: Zero
+        W: Zero,
     {
-        GeneratorBuilder{
+        GeneratorBuilder {
             grammar: self,
             beam: None,
             delta: W::zero(),
             candidates: None,
-            root_prediction: false
+            root_prediction: false,
         }
     }
 }
 
-impl<N, T, W> CSRepresentation<N, T, W> where T: Hash + Eq {
+impl<N, T, W> CSRepresentation<N, T, W>
+where
+    T: Hash + Eq,
+{
     /// Reads off a parse tree from a multiply Dyck word. Fails if the word is not in R ∩ D.
     fn toderiv<'a>(&'a self, word: &[Delta]) -> Option<GornTree<&'a PMCFGRule<N, T, W>>> {
         let mut tree = BTreeMap::new();
@@ -214,8 +278,8 @@ impl<N, T, W> CSRepresentation<N, T, W> where T: Hash + Eq {
 
 #[cfg(test)]
 mod test {
-    use crate::grammars::pmcfg::{VarT, PMCFGRule, Composition};
     use super::{CSRepresentation, Lcfrs};
+    use crate::grammars::pmcfg::{Composition, PMCFGRule, VarT};
     use log_domain::LogDomain;
 
     #[test]
@@ -226,11 +290,15 @@ mod test {
             (vec![], &grammar.rules[0]),
             (vec![0], &grammar.rules[1]),
             (vec![1], &grammar.rules[1]),
-        ].into_iter()
-            .collect();
+        ]
+        .into_iter()
+        .collect();
 
         let cs = CSRepresentation::new(grammar.clone(), 0);
-        assert_eq!(cs.build_generator().with_fallback(&['A']).0.next(), Some(d1));
+        assert_eq!(
+            cs.build_generator().with_fallback(&['A']).0.next(),
+            Some(d1)
+        );
         assert_eq!(
             cs.build_generator().with_fallback(&['A', 'A']).0.next(),
             Some(d2)
@@ -252,7 +320,9 @@ mod test {
                 PMCFGRule {
                     head: "S",
                     tail: vec![],
-                    composition: Composition { composition: vec![vec![VarT::T('A')]] },
+                    composition: Composition {
+                        composition: vec![vec![VarT::T('A')]],
+                    },
                     weight: LogDomain::new(0.7f64).unwrap(),
                 },
             ],

--- a/src/grammars/lcfrs/csparsing/mod.rs
+++ b/src/grammars/lcfrs/csparsing/mod.rs
@@ -3,9 +3,9 @@ mod automaton;
 
 use super::Lcfrs;
 
-use dyck::Bracket;
-use grammars::pmcfg::PMCFGRule;
-use util::{ tree::GornTree, factorizable::Factorizable };
+use crate::dyck::Bracket;
+use crate::grammars::pmcfg::PMCFGRule;
+use crate::util::{ tree::GornTree, factorizable::Factorizable };
 use std::{ collections::{BTreeMap}, fmt::{Display, Error, Formatter}, hash::Hash, ops::Mul };
 use num_traits::{Zero, One};
 use std::time::{Instant, Duration};
@@ -157,7 +157,7 @@ where
         assert!(estimates_max_width <= u8::max_value() as usize);
         let (rules, initial) = grammar.into().destruct();
         let generator = {
-            let mut rules_with_id = rules.iter().enumerate().map(|(i, r)| (i as u32, r));
+            let rules_with_id = rules.iter().enumerate().map(|(i, r)| (i as u32, r));
             Automaton::from_grammar(rules_with_id, initial.clone())
         };
         let rulemaskbuilder = RuleMaskBuilder::new(rules.iter(), &initial);
@@ -214,7 +214,7 @@ impl<N, T, W> CSRepresentation<N, T, W> where T: Hash + Eq {
 
 #[cfg(test)]
 mod test {
-    use grammars::pmcfg::{VarT, PMCFGRule, Composition};
+    use crate::grammars::pmcfg::{VarT, PMCFGRule, Composition};
     use super::{CSRepresentation, Lcfrs};
     use log_domain::LogDomain;
 

--- a/src/grammars/lcfrs/from_discodop.rs
+++ b/src/grammars/lcfrs/from_discodop.rs
@@ -1,16 +1,16 @@
 use super::*;
-use nom::*;
-use std::ops::{Div, DivAssign, AddAssign};
-use std::str::FromStr;
-use std::fmt::Debug;
-use std::collections::{hash_map::Entry};
 use fnv::FnvHashMap;
+use nom::*;
 use num_traits::One;
+use std::collections::hash_map::Entry;
+use std::fmt::Debug;
+use std::ops::{AddAssign, Div, DivAssign};
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
 enum DiscoDeriv<N> {
-    Chain{ lhs: N, rhs: N },
-    Binary{ lhs: N, rhs1: N, rhs2: N }
+    Chain { lhs: N, rhs: N },
+    Binary { lhs: N, rhs1: N, rhs2: N },
 }
 type DiscoYield = Vec<(u8, u64)>;
 #[derive(Debug)]
@@ -21,25 +21,35 @@ pub struct DiscoLexer<N, T, W>(Vec<(T, N, W)>);
 #[derive(Debug)]
 pub struct DiscoDopGrammar<N, T, W> {
     pub constituents: DiscoConstituents<N, W>,
-    pub lexer: Option<DiscoLexer<N, T, W>>
+    pub lexer: Option<DiscoLexer<N, T, W>>,
 }
 
-fn is_token(c: char) -> bool { !c.is_whitespace() }
-fn is_binary_digit(c: char) -> bool { c == '0' || c == '1' }
+fn is_token(c: char) -> bool {
+    !c.is_whitespace()
+}
+fn is_binary_digit(c: char) -> bool {
+    c == '0' || c == '1'
+}
 
 /// Interprets a string over { '0', '1' } in reverse as an integer in binary format.
 fn from_binary(s: &str) -> Option<u64> {
     s.chars()
-     .enumerate()
-     .map(|(i,c)| match c { '0' => Some(0), '1' => Some(2u64.pow(i as u32)), _ => None })
-     .fold(Some(0), |os, ov| os.and_then(|s| ov.and_then(|v| Some(v + s))))
+        .enumerate()
+        .map(|(i, c)| match c {
+            '0' => Some(0),
+            '1' => Some(2u64.pow(i as u32)),
+            _ => None,
+        })
+        .fold(Some(0), |os, ov| {
+            os.and_then(|s| ov.and_then(|v| Some(v + s)))
+        })
 }
 
 impl<N> DiscoDeriv<N> {
     fn get_lhs(&self) -> &N {
         match *self {
-            DiscoDeriv::Chain{ ref lhs, .. } => lhs,
-            DiscoDeriv::Binary{ ref lhs, .. } => lhs
+            DiscoDeriv::Chain { ref lhs, .. } => lhs,
+            DiscoDeriv::Binary { ref lhs, .. } => lhs,
         }
     }
 }
@@ -66,12 +76,12 @@ named!(parse_yield<&str,DiscoYield>,
 /// integer values.
 fn parse_pseudocount<W>(s: &str) -> IResult<&str, W>
 where
-    W: Div<Output=W> + FromStr,
+    W: Div<Output = W> + FromStr,
 {
     map_res!(
         s,
         tuple!(digit, opt!(complete!(preceded!(tag!("/"), digit)))),
-        |(num,denom): (&str, Option<&str>)| -> Result<W, W::Err> {
+        |(num, denom): (&str, Option<&str>)| -> Result<W, W::Err> {
             if let Some(denominator) = denom {
                 let numerator: W = num.parse()?;
                 let denominator: W = denominator.parse()?;
@@ -85,7 +95,8 @@ where
 
 #[derive(Debug, Clone, Copy)]
 pub enum ParseLexerError {
-    Lhs, Rhs
+    Lhs,
+    Rhs,
 }
 /// Parse a lexer file.
 /// Word-POS-weight-pairs are given in a list of POS-weight pairs for a word in each line.
@@ -93,7 +104,7 @@ fn parse_discodop_lexer<N, T, W>(s: &str) -> IResult<&str, DiscoLexer<N, T, W>>
 where
     N: FromStr,
     T: FromStr,
-    W: Div<Output=W> + FromStr,
+    W: Div<Output = W> + FromStr,
 {
     map_res!(
         s,
@@ -103,10 +114,7 @@ where
                 terminated!(take_while!(is_token), space),
                 separated_nonempty_list_complete!(
                     space,
-                    tuple!(
-                        terminated!(take_while!(is_token), space),
-                        parse_pseudocount
-                    )
+                    tuple!(terminated!(take_while!(is_token), space), parse_pseudocount)
                 )
             )
         ),
@@ -124,9 +132,12 @@ where
     )
 }
 
-#[derive(Debug,Clone,Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum ParseConsituentsError {
-    Lhs, Rhs, Weight, Yield
+    Lhs,
+    Rhs,
+    Weight,
+    Yield,
 }
 /// Parse a list of Constituent rules given in disco-dop's format.
 /// Each line contains a rule with tab-separaterd values for:
@@ -137,7 +148,7 @@ pub enum ParseConsituentsError {
 fn parse_discodop_constituents<N, W>(s: &str) -> IResult<&str, DiscoConstituents<N, W>>
 where
     N: FromStr,
-    W: Div<Output=W> + FromStr,
+    W: Div<Output = W> + FromStr,
 {
     map!(
         s,
@@ -148,7 +159,7 @@ where
                     take_while1!(is_token),
                     count_fixed!(&str, preceded!(space, take_while1!(is_token)), 3),
                     opt!(complete!(preceded!(space, take_while1!(is_token))))
-                ), 
+                ),
                 |(s_lhs, [s_rhs, s_rhs_or_y, s_y_or_w], s_ow): (&str, [&str;3], Option<&str>)| -> Result<(DiscoDeriv<N>, DiscoYield, W), ParseConsituentsError> {
                     let lhs = s_lhs.parse().map_err(|_| ParseConsituentsError::Lhs)?;
                     let rhs = s_rhs.parse().map_err(|_| ParseConsituentsError::Rhs)?;
@@ -168,7 +179,6 @@ where
     )
 }
 
-
 impl<N, T, W> From<DiscoDopGrammar<N, T, W>> for Lcfrs<N, T, W>
 where
     W: DivAssign + Copy + AddAssign,
@@ -176,14 +186,30 @@ where
     <N as FromStr>::Err: Debug,
 {
     fn from(gmr: DiscoDopGrammar<N, T, W>) -> Self {
-        let mut rules = Vec::with_capacity(gmr.constituents.0.len() + gmr.lexer.as_ref().map_or(0, |l| l.0.len()));
+        let mut rules = Vec::with_capacity(
+            gmr.constituents.0.len() + gmr.lexer.as_ref().map_or(0, |l| l.0.len()),
+        );
 
         let mut normalization_denominators: FnvHashMap<N, W> = HashMap::default();
-        for (lhs, weight) in gmr.constituents.0.iter().map(|&(ref d, _, w)| (d.get_lhs(), w))
-                                .chain(gmr.lexer.iter().flat_map(|l| &l.0).map(|&(_, ref lhs, w)| (lhs, w))) {
+        for (lhs, weight) in gmr
+            .constituents
+            .0
+            .iter()
+            .map(|&(ref d, _, w)| (d.get_lhs(), w))
+            .chain(
+                gmr.lexer
+                    .iter()
+                    .flat_map(|l| &l.0)
+                    .map(|&(_, ref lhs, w)| (lhs, w)),
+            )
+        {
             match normalization_denominators.entry(lhs.clone()) {
-                Entry::Occupied(mut oe) => { *oe.get_mut() += weight; },
-                Entry::Vacant(ve) => { ve.insert(weight); }
+                Entry::Occupied(mut oe) => {
+                    *oe.get_mut() += weight;
+                }
+                Entry::Vacant(ve) => {
+                    ve.insert(weight);
+                }
             }
         }
 
@@ -197,29 +223,52 @@ where
             for (clen, c) in y {
                 let mut component = Vec::with_capacity(clen as usize);
                 for i in 0..clen {
-                    if 2u64.pow(i as u32) & c == 0 { component.push(VarT::Var(0, sind1)); sind1 += 1; }
-                    else { component.push(VarT::Var(1, sind2)); sind2 += 1; }
+                    if 2u64.pow(i as u32) & c == 0 {
+                        component.push(VarT::Var(0, sind1));
+                        sind1 += 1;
+                    } else {
+                        component.push(VarT::Var(1, sind2));
+                        sind2 += 1;
+                    }
                 }
                 composition.push(component);
             }
 
             // compose rules using yield function and nonterminals
             match nts {
-                DiscoDeriv::Chain{ lhs, rhs } => {
-                    rules.push(PMCFGRule{ head: lhs, tail: vec![rhs], weight: weight, composition: composition.into() });
+                DiscoDeriv::Chain { lhs, rhs } => {
+                    rules.push(PMCFGRule {
+                        head: lhs,
+                        tail: vec![rhs],
+                        weight: weight,
+                        composition: composition.into(),
+                    });
                 }
-                DiscoDeriv::Binary{ lhs, rhs1, rhs2 } => {
-                    rules.push(PMCFGRule{ head: lhs, tail: vec![rhs1, rhs2], weight, composition: composition.into() });
+                DiscoDeriv::Binary { lhs, rhs1, rhs2 } => {
+                    rules.push(PMCFGRule {
+                        head: lhs,
+                        tail: vec![rhs1, rhs2],
+                        weight,
+                        composition: composition.into(),
+                    });
                 }
             }
         }
 
         for (word, pos, mut weight) in gmr.lexer.into_iter().flat_map(|dl| dl.0) {
             weight /= normalization_denominators[&pos];
-            rules.push(PMCFGRule{ head: pos, tail: vec![], weight, composition: vec![vec![VarT::T(word)]].into() })
+            rules.push(PMCFGRule {
+                head: pos,
+                tail: vec![],
+                weight,
+                composition: vec![vec![VarT::T(word)]].into(),
+            })
         }
 
-        Lcfrs{ rules, init: "ROOT".parse::<N>().unwrap() }
+        Lcfrs {
+            rules,
+            init: "ROOT".parse::<N>().unwrap(),
+        }
     }
 }
 
@@ -227,55 +276,64 @@ impl<N, W> DiscoDopGrammar<N, (), W> {
     pub fn with_default_lexer(self) -> DiscoDopGrammar<N, N, W>
     where
         N: Clone + Hash + Eq,
-        W: One
+        W: One,
     {
         let mut lex = Vec::new();
-        
+
         {
             let mut is_only_on_rhs: FnvHashMap<&N, bool> = HashMap::default();
             for &(ref deriv, _, _) in &self.constituents.0 {
                 match *deriv {
-                    DiscoDeriv::Chain{ ref lhs, ref rhs } => {
+                    DiscoDeriv::Chain { ref lhs, ref rhs } => {
                         *is_only_on_rhs.entry(lhs).or_insert(false) = false;
                         is_only_on_rhs.entry(rhs).or_insert(true);
-                    },
-                    DiscoDeriv::Binary{ ref lhs, ref rhs1, ref rhs2 } => {
+                    }
+                    DiscoDeriv::Binary {
+                        ref lhs,
+                        ref rhs1,
+                        ref rhs2,
+                    } => {
                         *is_only_on_rhs.entry(lhs).or_insert(false) = false;
                         is_only_on_rhs.entry(rhs1).or_insert(true);
                         is_only_on_rhs.entry(rhs2).or_insert(true);
                     }
                 }
             }
-            
-            for p_pos in is_only_on_rhs.into_iter().filter_map(|(v, b)| if b { Some(v) } else { None }) {
+
+            for p_pos in is_only_on_rhs
+                .into_iter()
+                .filter_map(|(v, b)| if b { Some(v) } else { None })
+            {
                 lex.push(((*p_pos).clone(), (*p_pos).clone(), W::one()));
             }
         }
 
         DiscoDopGrammar {
             constituents: self.constituents,
-            lexer: Some(DiscoLexer(lex))
+            lexer: Some(DiscoLexer(lex)),
         }
     }
 
     pub fn with_lexer<T>(self, lexer: DiscoLexer<N, T, W>) -> DiscoDopGrammar<N, T, W> {
-        DiscoDopGrammar{ constituents: self.constituents, lexer: Some(lexer) }
+        DiscoDopGrammar {
+            constituents: self.constituents,
+            lexer: Some(lexer),
+        }
     }
 }
 
 impl<N, W> FromStr for DiscoDopGrammar<N, (), W>
 where
     N: FromStr,
-    W: Div<Output=W> + FromStr,
+    W: Div<Output = W> + FromStr,
     <W as FromStr>::Err: Debug,
     <N as FromStr>::Err: Debug,
 {
     type Err = nom::Err<u32>;
-    fn from_str(constituent_str: &str) -> Result<Self, Self::Err>
-    {
-        Ok(DiscoDopGrammar{
+    fn from_str(constituent_str: &str) -> Result<Self, Self::Err> {
+        Ok(DiscoDopGrammar {
             constituents: parse_discodop_constituents(constituent_str).to_result()?,
-            lexer: None
+            lexer: None,
         })
     }
 }
@@ -284,7 +342,7 @@ impl<N, T, W> FromStr for DiscoLexer<N, T, W>
 where
     N: FromStr,
     T: FromStr,
-    W: Div<Output=W> + FromStr,
+    W: Div<Output = W> + FromStr,
     <W as FromStr>::Err: Debug,
     <N as FromStr>::Err: Debug,
     <T as FromStr>::Err: Debug,
@@ -300,37 +358,36 @@ mod test {
     use super::*;
 
     #[test]
-    fn weight () {
-        let ws = vec![
-            ("1", 1f64),
-            ("1000", 1000f64),
-            ("23/64", 23f64 / 64f64)
-        ];
+    fn weight() {
+        let ws = vec![("1", 1f64), ("1000", 1000f64), ("23/64", 23f64 / 64f64)];
         for (s, w) in ws {
             assert_eq!(parse_pseudocount::<f64>(s).unwrap().1, w);
         }
     }
 
     #[test]
-    fn lexer () {
-        let lex = parse_discodop_lexer(&"is\tVB\t1/2\nJohn\tNN\t1\nrich\tJJ\t1/4\nstain\tNN\t2/8\tVP\t3");
+    fn lexer() {
+        let lex =
+            parse_discodop_lexer(&"is\tVB\t1/2\nJohn\tNN\t1\nrich\tJJ\t1/4\nstain\tNN\t2/8\tVP\t3");
         assert_eq!(
-            (lex.unwrap().1).0, 
-            vec![ ("is".to_string(), "VB".to_string(), 0.5f64),
-                  ("John".to_string(), "NN".to_string(), 1f64),
-                  ("rich".to_string(), "JJ".to_string(), 0.25f64),
-                  ("stain".to_string(), "NN".to_string(), 0.25f64),
-                  ("stain".to_string(), "VP".to_string(), 3f64) ]
+            (lex.unwrap().1).0,
+            vec![
+                ("is".to_string(), "VB".to_string(), 0.5f64),
+                ("John".to_string(), "NN".to_string(), 1f64),
+                ("rich".to_string(), "JJ".to_string(), 0.25f64),
+                ("stain".to_string(), "NN".to_string(), 0.25f64),
+                ("stain".to_string(), "VP".to_string(), 3f64)
+            ]
         )
     }
 
     #[test]
-    fn yield_binary () {
+    fn yield_binary() {
         let ys = vec![
             ("000", Some(0b0)),
             ("10111010", Some(0b01011101)),
             ("", Some(0b0)),
-            ("2", None)
+            ("2", None),
         ];
         for (y, yp) in ys {
             assert_eq!(from_binary(y), yp);
@@ -338,12 +395,24 @@ mod test {
     }
 
     #[test]
-    fn yield_repr () {
+    fn yield_repr() {
         let ys = vec![
             ("000,11111", vec![(3, 0b000), (5, 0b11111)]),
             ("0101010,10111010", vec![(7, 0b0101010), (8, 0b01011101)]),
             ("0", vec![(1, 0b0)]),
-            ("1,0,1,0,10100,01,0,1", vec![(1, 0b1),(1, 0),(1, 0b1),(1, 0b0),(5, 0b00101),(2, 0b10),(1, 0b0),(1, 0b1)]),
+            (
+                "1,0,1,0,10100,01,0,1",
+                vec![
+                    (1, 0b1),
+                    (1, 0),
+                    (1, 0b1),
+                    (1, 0b0),
+                    (5, 0b00101),
+                    (2, 0b10),
+                    (1, 0b0),
+                    (1, 0b1),
+                ],
+            ),
         ];
 
         for (y, yv) in ys {
@@ -353,47 +422,156 @@ mod test {
     }
 
     #[test]
-    fn const_rule () {
+    fn const_rule() {
         let ds = vec![
-            ("S\tNP\tVP\t01,10\t5", (DiscoDeriv::Binary{ lhs: "S".to_string(), rhs1: "NP".to_string(), rhs2: "VP".to_string() }, vec![(2,0b10),(2,0b01)], 5f64)),
-            ("S\tA\t0\t1", (DiscoDeriv::Chain{ lhs: "S".to_string(), rhs: "A".to_string() }, vec![(1,0b0)], 1f64)),
-            ("NP_1\tDET_2\tNP_55\t0001,11110,001010,0010100\t5", (DiscoDeriv::Binary{ lhs: "NP_1".to_string(), rhs1: "DET_2".to_string(), rhs2: "NP_55".to_string() }, vec![(4,0b1000),(5,0b01111),(6,0b010100),(7,0b0010100)], 5f64)),
-            ("NP|<DET>\tNP\t0110\t64", (DiscoDeriv::Chain{ lhs:"NP|<DET>".to_string(), rhs: "NP".to_string() }, vec![(4,0b0110)], 64f64)),
+            (
+                "S\tNP\tVP\t01,10\t5",
+                (
+                    DiscoDeriv::Binary {
+                        lhs: "S".to_string(),
+                        rhs1: "NP".to_string(),
+                        rhs2: "VP".to_string(),
+                    },
+                    vec![(2, 0b10), (2, 0b01)],
+                    5f64,
+                ),
+            ),
+            (
+                "S\tA\t0\t1",
+                (
+                    DiscoDeriv::Chain {
+                        lhs: "S".to_string(),
+                        rhs: "A".to_string(),
+                    },
+                    vec![(1, 0b0)],
+                    1f64,
+                ),
+            ),
+            (
+                "NP_1\tDET_2\tNP_55\t0001,11110,001010,0010100\t5",
+                (
+                    DiscoDeriv::Binary {
+                        lhs: "NP_1".to_string(),
+                        rhs1: "DET_2".to_string(),
+                        rhs2: "NP_55".to_string(),
+                    },
+                    vec![(4, 0b1000), (5, 0b01111), (6, 0b010100), (7, 0b0010100)],
+                    5f64,
+                ),
+            ),
+            (
+                "NP|<DET>\tNP\t0110\t64",
+                (
+                    DiscoDeriv::Chain {
+                        lhs: "NP|<DET>".to_string(),
+                        rhs: "NP".to_string(),
+                    },
+                    vec![(4, 0b0110)],
+                    64f64,
+                ),
+            ),
         ];
         for (s, deriv) in ds {
-            assert_eq!( (parse_discodop_constituents(s).unwrap().1).0, vec![deriv] );
+            assert_eq!((parse_discodop_constituents(s).unwrap().1).0, vec![deriv]);
         }
     }
 
     #[test]
-    fn constituents () {
-        let cons = parse_discodop_constituents("S\tNP\tVP\t010\t1\nNP_2\tVP\tNP\t0,1\t2\nNP\tNN\t0\t4");
+    fn constituents() {
+        let cons =
+            parse_discodop_constituents("S\tNP\tVP\t010\t1\nNP_2\tVP\tNP\t0,1\t2\nNP\tNN\t0\t4");
         assert_eq!(
             (cons.unwrap().1).0,
             vec![
-                (DiscoDeriv::Binary{ lhs: "S".to_string(), rhs1: "NP".to_string(), rhs2: "VP".to_string() }, vec![(3,0b010)], 1f64),
-                (DiscoDeriv::Binary{ lhs: "NP_2".to_string(), rhs1: "VP".to_string(), rhs2: "NP".to_string()}, vec![(1u8,0b0u64),(1,0b1)], 2f64),
-                (DiscoDeriv::Chain{ lhs: "NP".to_string(), rhs: "NN".to_string() }, vec![(1,0b0)], 4f64),
+                (
+                    DiscoDeriv::Binary {
+                        lhs: "S".to_string(),
+                        rhs1: "NP".to_string(),
+                        rhs2: "VP".to_string()
+                    },
+                    vec![(3, 0b010)],
+                    1f64
+                ),
+                (
+                    DiscoDeriv::Binary {
+                        lhs: "NP_2".to_string(),
+                        rhs1: "VP".to_string(),
+                        rhs2: "NP".to_string()
+                    },
+                    vec![(1u8, 0b0u64), (1, 0b1)],
+                    2f64
+                ),
+                (
+                    DiscoDeriv::Chain {
+                        lhs: "NP".to_string(),
+                        rhs: "NN".to_string()
+                    },
+                    vec![(1, 0b0)],
+                    4f64
+                ),
             ]
         )
     }
 
     #[test]
-    fn conversion () {
-        let dlex = vec![("a", "DET".to_string(), 5f64),("word", "NP".to_string(), 6f64)];
-        let drules = vec![(DiscoDeriv::Binary{ lhs: "S".to_string(), rhs1: "NP".to_string(), rhs2: "VP".to_string() }, vec![(2, 0b10)], 5f64),(DiscoDeriv::Chain{ lhs: "NP".to_string(), rhs: "NP".to_string() }, vec![(2, 0b00)], 5f64)];
+    fn conversion() {
+        let dlex = vec![
+            ("a", "DET".to_string(), 5f64),
+            ("word", "NP".to_string(), 6f64),
+        ];
+        let drules = vec![
+            (
+                DiscoDeriv::Binary {
+                    lhs: "S".to_string(),
+                    rhs1: "NP".to_string(),
+                    rhs2: "VP".to_string(),
+                },
+                vec![(2, 0b10)],
+                5f64,
+            ),
+            (
+                DiscoDeriv::Chain {
+                    lhs: "NP".to_string(),
+                    rhs: "NP".to_string(),
+                },
+                vec![(2, 0b00)],
+                5f64,
+            ),
+        ];
 
-        let grmr: Lcfrs<String, &str, f64> = DiscoDopGrammar{
+        let grmr: Lcfrs<String, &str, f64> = DiscoDopGrammar {
             lexer: Some(DiscoLexer(dlex)),
-            constituents: DiscoConstituents(drules)
-        }.into();
+            constituents: DiscoConstituents(drules),
+        }
+        .into();
         assert_eq!(grmr.init, "ROOT");
-        assert_eq!(grmr.rules,
+        assert_eq!(
+            grmr.rules,
             vec![
-                PMCFGRule{ head: "S".to_string(), tail: vec!["NP".to_string(), "VP".to_string()], composition: vec![vec![VarT::Var(0,0), VarT::Var(1,0)]].into(), weight: 5f64 },
-                PMCFGRule{ head: "NP".to_string(), tail: vec!["NP".to_string()], composition: vec![vec![VarT::Var(0,0), VarT::Var(0,1)]].into(), weight: 5f64 },
-                PMCFGRule{ head: "DET".to_string(), tail: vec![], composition: vec![vec![VarT::T("a")]].into(), weight: 5f64 },
-                PMCFGRule{ head: "NP".to_string(), tail: vec![], composition: vec![vec![VarT::T("word")]].into(), weight: 6f64 },
+                PMCFGRule {
+                    head: "S".to_string(),
+                    tail: vec!["NP".to_string(), "VP".to_string()],
+                    composition: vec![vec![VarT::Var(0, 0), VarT::Var(1, 0)]].into(),
+                    weight: 5f64
+                },
+                PMCFGRule {
+                    head: "NP".to_string(),
+                    tail: vec!["NP".to_string()],
+                    composition: vec![vec![VarT::Var(0, 0), VarT::Var(0, 1)]].into(),
+                    weight: 5f64
+                },
+                PMCFGRule {
+                    head: "DET".to_string(),
+                    tail: vec![],
+                    composition: vec![vec![VarT::T("a")]].into(),
+                    weight: 5f64
+                },
+                PMCFGRule {
+                    head: "NP".to_string(),
+                    tail: vec![],
+                    composition: vec![vec![VarT::T("word")]].into(),
+                    weight: 6f64
+                },
             ]
         )
     }

--- a/src/grammars/lcfrs/from_rparse.rs
+++ b/src/grammars/lcfrs/from_rparse.rs
@@ -1,19 +1,21 @@
-use nom::*;
-use std::str::FromStr;
-use std::fmt::Debug;
 use super::*;
+use nom::*;
+use std::fmt::Debug;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
 enum Rhs<N> {
     Binary(N, N),
-    Chain(N)
+    Chain(N),
 }
 type Yield = Vec<Vec<bool>>;
 
 #[derive(Debug)]
 struct RparseClauses<N, W>(Vec<(W, N, Rhs<N>, Yield)>);
 
-fn is_token(c: char) -> bool { !c.is_whitespace() }
+fn is_token(c: char) -> bool {
+    !c.is_whitespace()
+}
 
 named!(parse_rparse_yield<&str, Yield>,
     delimited!(
@@ -48,16 +50,25 @@ where
         separated_nonempty_list_complete!(
             tag!("\n"),
             do_parse!(
-                terminated!(digit, space)                                                   >>
-                weight: take_while1!(|c| is_token(c) && c != ':')                           >>
-                tag!(":")                                                                   >>
-                lhs: take_while1!(is_token)                                                 >>
-                delimited!(space, tag!("-->"), space)                                       >>
-                rhs1: take_while1!(is_token)                                                >>
-                space                                                                       >>
-                o_rhs2: opt!(delimited!(not!(tag!("[[[")), take_while1!(is_token), space))  >>
-                y: complete!(parse_rparse_yield)                                            >>
-                (weight.parse().unwrap(), lhs.parse().unwrap(), if let Some(rhs2) = o_rhs2 { Rhs::Binary(rhs1.parse().unwrap(), rhs2.parse().unwrap()) } else { Rhs::Chain(rhs1.parse().unwrap()) }, y)
+                terminated!(digit, space)
+                    >> weight: take_while1!(|c| is_token(c) && c != ':')
+                    >> tag!(":")
+                    >> lhs: take_while1!(is_token)
+                    >> delimited!(space, tag!("-->"), space)
+                    >> rhs1: take_while1!(is_token)
+                    >> space
+                    >> o_rhs2: opt!(delimited!(not!(tag!("[[[")), take_while1!(is_token), space))
+                    >> y: complete!(parse_rparse_yield)
+                    >> (
+                        weight.parse().unwrap(),
+                        lhs.parse().unwrap(),
+                        if let Some(rhs2) = o_rhs2 {
+                            Rhs::Binary(rhs1.parse().unwrap(), rhs2.parse().unwrap())
+                        } else {
+                            Rhs::Chain(rhs1.parse().unwrap())
+                        },
+                        y
+                    )
             )
         ),
         RparseClauses
@@ -65,7 +76,7 @@ where
 }
 
 impl<N, W> FromStr for RparseClauses<N, W>
-where 
+where
     N: FromStr,
     W: FromStr,
     <N as FromStr>::Err: Debug,
@@ -75,7 +86,7 @@ where
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match parse_rparse_clauses(s) {
             IResult::Done(_, clauses) => Ok(clauses),
-            _ => Err(())
+            _ => Err(()),
         }
     }
 }
@@ -83,14 +94,14 @@ where
 impl<N, W> Into<Lcfrs<N, (), W>> for RparseClauses<N, W>
 where
     N: FromStr,
-    <N as FromStr>::Err: Debug
+    <N as FromStr>::Err: Debug,
 {
     fn into(self) -> Lcfrs<N, (), W> {
         let mut rules = Vec::with_capacity(self.0.len());
         for (weight, lhs, rhs, y) in self.0 {
             let tail = match rhs {
                 Rhs::Chain(a) => vec![a],
-                Rhs::Binary(a, b) => vec![a, b]
+                Rhs::Binary(a, b) => vec![a, b],
             };
 
             let mut composition = Vec::with_capacity(y.len());
@@ -99,18 +110,29 @@ where
             for ycomp in y {
                 let mut component = Vec::with_capacity(ycomp.len());
                 for snd_or_fst in ycomp {
-                    if snd_or_fst { component.push(VarT::Var(1, ind2)); ind2 += 1; }
-                    else { component.push(VarT::Var(0, ind1)); ind1 += 1; }
+                    if snd_or_fst {
+                        component.push(VarT::Var(1, ind2));
+                        ind2 += 1;
+                    } else {
+                        component.push(VarT::Var(0, ind1));
+                        ind1 += 1;
+                    }
                 }
                 composition.push(component);
             }
 
-            rules.push(
-                PMCFGRule{ head: lhs, tail, weight, composition: composition.into() }
-            );
+            rules.push(PMCFGRule {
+                head: lhs,
+                tail,
+                weight,
+                composition: composition.into(),
+            });
         }
 
-        Lcfrs{ rules, init: "VROOT1".parse().unwrap() }
+        Lcfrs {
+            rules,
+            init: "VROOT1".parse().unwrap(),
+        }
     }
 }
 
@@ -119,45 +141,103 @@ mod test {
     use super::*;
 
     #[test]
-    fn rparse_yield () {
+    fn rparse_yield() {
         let ys = vec![
             ("[[[false]]]", vec![vec![false]]),
             ("[[[false], [true]]]", vec![vec![false], vec![true]]),
-            ("[[[false, true, false], [false], [true, false, false]]]", vec![vec![false, true, false], vec![false], vec![true, false, false]]),
+            (
+                "[[[false, true, false], [false], [true, false, false]]]",
+                vec![
+                    vec![false, true, false],
+                    vec![false],
+                    vec![true, false, false],
+                ],
+            ),
         ];
         for (s, y) in ys {
-            assert_eq!(
-                y,
-                parse_rparse_yield(s).unwrap().1
-            );
+            assert_eq!(y, parse_rparse_yield(s).unwrap().1);
         }
     }
 
     #[test]
-    fn rparse_clauses () {
+    fn rparse_clauses() {
         let ds = vec![
-            ("10925 0.66:VROOT1 --> S1 $.1 [[[false, true]]]", (0.66, "VROOT1".to_owned(), Rhs::Binary("S1".to_owned(), "$.1".to_owned()), vec![vec![false, true]])),
-            ("1 6.047046018020197E-5:VROOT1 --> ADV1 $(1 [[[false, true]]]", (6.047046018020197E-5, "VROOT1".to_owned(), Rhs::Binary("ADV1".to_owned(), "$(1".to_owned()), vec![vec![false, true]])),
-            ("2 0.006557377049180328:PP2 --> @^PP2^VP3-APPRART1X2  [[[false], [false]]]", (0.006557377049180328, "PP2".to_owned(), Rhs::Chain("@^PP2^VP3-APPRART1X2".to_owned()), vec![vec![false], vec![false]]))
+            (
+                "10925 0.66:VROOT1 --> S1 $.1 [[[false, true]]]",
+                (
+                    0.66,
+                    "VROOT1".to_owned(),
+                    Rhs::Binary("S1".to_owned(), "$.1".to_owned()),
+                    vec![vec![false, true]],
+                ),
+            ),
+            (
+                "1 6.047046018020197E-5:VROOT1 --> ADV1 $(1 [[[false, true]]]",
+                (
+                    6.047046018020197E-5,
+                    "VROOT1".to_owned(),
+                    Rhs::Binary("ADV1".to_owned(), "$(1".to_owned()),
+                    vec![vec![false, true]],
+                ),
+            ),
+            (
+                "2 0.006557377049180328:PP2 --> @^PP2^VP3-APPRART1X2  [[[false], [false]]]",
+                (
+                    0.006557377049180328,
+                    "PP2".to_owned(),
+                    Rhs::Chain("@^PP2^VP3-APPRART1X2".to_owned()),
+                    vec![vec![false], vec![false]],
+                ),
+            ),
         ];
         for (s, deriv) in ds {
-            assert_eq!( (parse_rparse_clauses(s).unwrap().1).0, vec![deriv] );
+            assert_eq!((parse_rparse_clauses(s).unwrap().1).0, vec![deriv]);
         }
     }
 
     #[test]
-    fn conversion () {
+    fn conversion() {
         let clauses = vec![
-            (0.66, "VROOT1".to_owned(), Rhs::Binary("S1".to_owned(), "$.1".to_owned()), vec![vec![false, true]]),
-            (6.047046018020197E-5, "VROOT1".to_owned(), Rhs::Binary("ADV1".to_owned(), "$(1".to_owned()), vec![vec![false, true]]),
-            (0.006557377049180328, "PP2".to_owned(), Rhs::Chain("@^PP2^VP3-APPRART1X2".to_owned()), vec![vec![false], vec![false]])
+            (
+                0.66,
+                "VROOT1".to_owned(),
+                Rhs::Binary("S1".to_owned(), "$.1".to_owned()),
+                vec![vec![false, true]],
+            ),
+            (
+                6.047046018020197E-5,
+                "VROOT1".to_owned(),
+                Rhs::Binary("ADV1".to_owned(), "$(1".to_owned()),
+                vec![vec![false, true]],
+            ),
+            (
+                0.006557377049180328,
+                "PP2".to_owned(),
+                Rhs::Chain("@^PP2^VP3-APPRART1X2".to_owned()),
+                vec![vec![false], vec![false]],
+            ),
         ];
         let rules: Vec<PMCFGRule<String, (), f64>> = vec![
-            PMCFGRule{ head: "VROOT1".to_owned(), tail: vec!["S1".to_owned(), "$.1".to_owned()], weight: 0.66, composition: vec![vec![VarT::Var(0,0), VarT::Var(1,0)]].into() },
-            PMCFGRule{ head: "VROOT1".to_owned(), tail: vec!["ADV1".to_owned(), "$(1".to_owned()], weight: 6.047046018020197E-5, composition: vec![vec![VarT::Var(0,0), VarT::Var(1,0)]].into() },
-            PMCFGRule{ head: "PP2".to_owned(), tail: vec!["@^PP2^VP3-APPRART1X2".to_owned()], weight: 0.006557377049180328, composition: vec![vec![VarT::Var(0,0)], vec![VarT::Var(0,1)]].into() },
+            PMCFGRule {
+                head: "VROOT1".to_owned(),
+                tail: vec!["S1".to_owned(), "$.1".to_owned()],
+                weight: 0.66,
+                composition: vec![vec![VarT::Var(0, 0), VarT::Var(1, 0)]].into(),
+            },
+            PMCFGRule {
+                head: "VROOT1".to_owned(),
+                tail: vec!["ADV1".to_owned(), "$(1".to_owned()],
+                weight: 6.047046018020197E-5,
+                composition: vec![vec![VarT::Var(0, 0), VarT::Var(1, 0)]].into(),
+            },
+            PMCFGRule {
+                head: "PP2".to_owned(),
+                tail: vec!["@^PP2^VP3-APPRART1X2".to_owned()],
+                weight: 0.006557377049180328,
+                composition: vec![vec![VarT::Var(0, 0)], vec![VarT::Var(0, 1)]].into(),
+            },
         ];
-        
+
         let conv: Lcfrs<String, (), f64> = RparseClauses(clauses).into();
         assert_eq!(conv.rules, rules);
         assert_eq!(conv.init, "VROOT1".to_owned());

--- a/src/grammars/lcfrs/from_str.rs
+++ b/src/grammars/lcfrs/from_str.rs
@@ -1,9 +1,9 @@
+use num_traits::One;
 use std::fmt::Debug;
 use std::str::FromStr;
-use num_traits::One;
 
-use crate::util::parsing::initial_rule_grammar_from_str;
 use super::Lcfrs;
+use crate::util::parsing::initial_rule_grammar_from_str;
 
 impl<N, T, W> FromStr for Lcfrs<N, T, W>
 where

--- a/src/grammars/lcfrs/from_str.rs
+++ b/src/grammars/lcfrs/from_str.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::str::FromStr;
 use num_traits::One;
 
-use util::parsing::initial_rule_grammar_from_str;
+use crate::util::parsing::initial_rule_grammar_from_str;
 use super::Lcfrs;
 
 impl<N, T, W> FromStr for Lcfrs<N, T, W>

--- a/src/grammars/lcfrs/mod.rs
+++ b/src/grammars/lcfrs/mod.rs
@@ -1,5 +1,5 @@
-use grammars::pmcfg::PMCFGRule;
-use grammars::pmcfg::VarT;
+use crate::grammars::pmcfg::PMCFGRule;
+use crate::grammars::pmcfg::VarT;
 use std::hash::Hash;
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
@@ -123,9 +123,9 @@ fn check_composition<T>(composition: &[Vec<VarT<T>>], fanouts: &[usize]) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use grammars::pmcfg::{Composition, VarT};
+    use crate::grammars::pmcfg::{Composition, VarT};
     use std::collections::BTreeSet;
-    use grammars::mcfg::Mcfg;
+    use crate::grammars::mcfg::Mcfg;
 
     #[test]
     fn fanouts() {

--- a/src/grammars/mcfg/mod.rs
+++ b/src/grammars/mcfg/mod.rs
@@ -1,5 +1,5 @@
-use crate::grammars::pmcfg::{PMCFG, PMCFGRule};
 use crate::grammars::lcfrs::Lcfrs;
+use crate::grammars::pmcfg::{PMCFGRule, PMCFG};
 
 /// A mutliple context-free grammar.
 #[derive(Clone, Debug)]
@@ -27,22 +27,21 @@ impl<N, T, W> From<Lcfrs<N, T, W>> for Mcfg<N, T, W> {
 impl<N, T, W> Mcfg<N, T, W> {
     /// As long as `TryFrom` is unstable ...
     pub fn from_pmcfg(mut pmcfg: PMCFG<N, T, W>) -> Option<Self> {
-        use std::collections::BTreeSet;
         use crate::grammars::pmcfg::VarT;
+        use std::collections::BTreeSet;
 
         for rule in &pmcfg.rules {
             // check variables, return none if one occurs more than once
             let mut variables: BTreeSet<(usize, usize)> = BTreeSet::new();
             for (i, j) in rule.composition.composition.iter().flat_map(|component| {
-                component.iter().filter_map(
-                    |s| if let VarT::Var(i, j) = *s {
+                component.iter().filter_map(|s| {
+                    if let VarT::Var(i, j) = *s {
                         Some((i, j))
                     } else {
                         None
-                    },
-                )
-            })
-            {
+                    }
+                })
+            }) {
                 if !variables.insert((i, j)) {
                     return None;
                 }
@@ -58,6 +57,5 @@ impl<N, T, W> Mcfg<N, T, W> {
                 initial: pmcfg.initial.pop().unwrap(),
             })
         }
-
     }
 }

--- a/src/grammars/mcfg/mod.rs
+++ b/src/grammars/mcfg/mod.rs
@@ -1,5 +1,5 @@
-use grammars::pmcfg::{PMCFG, PMCFGRule};
-use grammars::lcfrs::Lcfrs;
+use crate::grammars::pmcfg::{PMCFG, PMCFGRule};
+use crate::grammars::lcfrs::Lcfrs;
 
 /// A mutliple context-free grammar.
 #[derive(Clone, Debug)]
@@ -28,7 +28,7 @@ impl<N, T, W> Mcfg<N, T, W> {
     /// As long as `TryFrom` is unstable ...
     pub fn from_pmcfg(mut pmcfg: PMCFG<N, T, W>) -> Option<Self> {
         use std::collections::BTreeSet;
-        use grammars::pmcfg::VarT;
+        use crate::grammars::pmcfg::VarT;
 
         for rule in &pmcfg.rules {
             // check variables, return none if one occurs more than once

--- a/src/grammars/pmcfg/from_str.rs
+++ b/src/grammars/pmcfg/from_str.rs
@@ -1,9 +1,9 @@
-use nom::{IResult, digit, is_space};
+use nom::{digit, is_space, IResult};
 use num_traits::One;
 use std::fmt::Debug;
-use std::str::{FromStr, from_utf8};
+use std::str::{from_utf8, FromStr};
 
-use crate::grammars::pmcfg::{Composition, PMCFG, PMCFGRule, VarT};
+use crate::grammars::pmcfg::{Composition, PMCFGRule, VarT, PMCFG};
 use crate::util::parsing::*;
 
 impl<N, T, W> FromStr for PMCFG<N, T, W>
@@ -62,31 +62,30 @@ where
 {
     do_parse!(
         input,
-        head: parse_token >>
-            take_while!(is_space) >>
-            alt!(tag!("→") | tag!("->") | tag!("=>")) >>
-            take_while!(is_space) >>
-            composition: parse_composition >>
-            take_while!(is_space) >>
-            tail: parse_successors >>
-            take_while!(is_space) >>
-            weight_o: opt!(
-                complete!(
-                    do_parse!(
-                        tag!("#") >>
-                            take_while!(is_space) >>
-                            weight_s: map_res!(is_not!(" "), from_utf8) >>
-                            (weight_s.parse().unwrap())
-                    )
-                )
-            ) >>
-            take_while!(is_space) >>
-            many0!(tag!("%")) >>
-            take_while!(|_| true) >>
-            (PMCFGRule {
+        head: parse_token
+            >> take_while!(is_space)
+            >> alt!(tag!("→") | tag!("->") | tag!("=>"))
+            >> take_while!(is_space)
+            >> composition: parse_composition
+            >> take_while!(is_space)
+            >> tail: parse_successors
+            >> take_while!(is_space)
+            >> weight_o:
+                opt!(complete!(do_parse!(
+                    tag!("#")
+                        >> take_while!(is_space)
+                        >> weight_s: map_res!(is_not!(" "), from_utf8)
+                        >> (weight_s.parse().unwrap())
+                )))
+            >> take_while!(is_space)
+            >> many0!(tag!("%"))
+            >> take_while!(|_| true)
+            >> (PMCFGRule {
                 head: head,
                 tail: tail,
-                composition: Composition { composition: composition },
+                composition: Composition {
+                    composition: composition
+                },
                 weight: weight_o.unwrap_or(W::one()),
             })
     )
@@ -99,26 +98,23 @@ where
 {
     do_parse!(
         input,
-        result: alt!(
-            do_parse!(
-                tag!("Var") >>
-                    take_while!(is_space) >>
-                    i: digit >>
-                    take_while!(is_space) >>
-                    j: digit >>
-                    (VarT::Var(
-                        from_utf8(i).unwrap().parse().unwrap(),
-                        from_utf8(j).unwrap().parse().unwrap(),
-                    ))
-            ) |
-            do_parse!(
-                tag!("T") >>
-                    take_while!(is_space) >>
-                    token: parse_token >>
-                    (VarT::T(token))
+        result:
+            alt!(
+                do_parse!(
+                    tag!("Var")
+                        >> take_while!(is_space)
+                        >> i: digit
+                        >> take_while!(is_space)
+                        >> j: digit
+                        >> (VarT::Var(
+                            from_utf8(i).unwrap().parse().unwrap(),
+                            from_utf8(j).unwrap().parse().unwrap(),
+                        ))
+                ) | do_parse!(
+                    tag!("T") >> take_while!(is_space) >> token: parse_token >> (VarT::T(token))
+                )
             )
-        ) >>
-            (result)
+            >> (result)
     )
 }
 

--- a/src/grammars/pmcfg/from_str.rs
+++ b/src/grammars/pmcfg/from_str.rs
@@ -3,8 +3,8 @@ use num_traits::One;
 use std::fmt::Debug;
 use std::str::{FromStr, from_utf8};
 
-use grammars::pmcfg::{Composition, PMCFG, PMCFGRule, VarT};
-use util::parsing::*;
+use crate::grammars::pmcfg::{Composition, PMCFG, PMCFGRule, VarT};
+use crate::util::parsing::*;
 
 impl<N, T, W> FromStr for PMCFG<N, T, W>
 where

--- a/src/grammars/pmcfg/mod.rs
+++ b/src/grammars/pmcfg/mod.rs
@@ -5,8 +5,8 @@ use std::iter::Extend;
 use std::slice;
 use std::vec;
 
-use crate::util::tree::GornTree;
 use crate::grammars::mcfg::Mcfg;
+use crate::util::tree::GornTree;
 
 mod from_str;
 pub mod negra;
@@ -36,13 +36,19 @@ impl<T> VarT<T> {
     }
 
     pub fn unwrap_var(&self) -> (usize, usize) {
-        if let &VarT::Var(i, j) = self { (i, j) }
-        else { panic!("unwrapped VarT was not a variable") }
+        if let &VarT::Var(i, j) = self {
+            (i, j)
+        } else {
+            panic!("unwrapped VarT was not a variable")
+        }
     }
 
     pub fn unwrap_t(&self) -> &T {
-        if let &VarT::T(ref t) = self { t }
-        else { panic!("unwrapped VarT was not a terminal") }
+        if let &VarT::T(ref t) = self {
+            t
+        } else {
+            panic!("unwrapped VarT was not a terminal")
+        }
     }
 }
 
@@ -64,7 +70,9 @@ impl<T> Composition<T> {
 
 impl<T> From<Vec<Vec<VarT<T>>>> for Composition<T> {
     fn from(encapsulated_value: Vec<Vec<VarT<T>>>) -> Self {
-        Composition { composition: encapsulated_value }
+        Composition {
+            composition: encapsulated_value,
+        }
     }
 }
 
@@ -250,10 +258,7 @@ impl<N: fmt::Display, T: fmt::Display, W: fmt::Display> fmt::Display for PMCFGRu
         write!(
             f,
             "\"{}\" → {} {}  # {}",
-            self.head,
-            self.composition,
-            buffer,
-            self.weight
+            self.head, self.composition, buffer, self.weight
         )
         // write!(f, "\"{}\" → {}", self.head, self.composition)
     }
@@ -348,13 +353,15 @@ where
     let mut term_map = GornTree::new();
     let mut head_map = GornTree::new();
 
-    for (address,
-         &PMCFGRule {
-             ref head,
-             tail: _,
-             ref composition,
-             weight: _,
-         }) in tree_map
+    for (
+        address,
+        &PMCFGRule {
+            ref head,
+            tail: _,
+            ref composition,
+            weight: _,
+        },
+    ) in tree_map
     {
         term_map.insert(address.clone(), composition.clone());
         head_map.insert(address.clone(), head.clone());
@@ -427,24 +434,28 @@ where
     let mut new_tree = GornTree::new();
     let mut old_heads = Vec::new();
 
-    for (_,
-         &PMCFGRule {
-             ref head,
-             tail: _,
-             composition: _,
-             weight: _,
-         }) in tree_map
+    for (
+        _,
+        &PMCFGRule {
+            ref head,
+            tail: _,
+            composition: _,
+            weight: _,
+        },
+    ) in tree_map
     {
         old_heads.push(head.clone());
     }
 
-    for (address,
-         &PMCFGRule {
-             ref head,
-             ref tail,
-             ref composition,
-             ref weight,
-         }) in tree_map
+    for (
+        address,
+        &PMCFGRule {
+            ref head,
+            ref tail,
+            ref composition,
+            ref weight,
+        },
+    ) in tree_map
     {
         let mut next_child_num = tail.len()..;
         let mut terminal_child_num = HashMap::new();
@@ -534,8 +545,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use self::VarT::{Var, T};
+    use super::*;
     use std::str::FromStr;
 
     pub fn example_tree_map() -> GornTree<PMCFGRule<String, String, usize>> {
@@ -543,20 +554,17 @@ mod tests {
 
         tree_map.insert(
             vec![],
-            PMCFGRule::from_str("S -> [[Var 0 0, Var 1 0, Var 0 1, Var 1 1]] (A, B) # 1")
-                .unwrap(),
+            PMCFGRule::from_str("S -> [[Var 0 0, Var 1 0, Var 0 1, Var 1 1]] (A, B) # 1").unwrap(),
         );
         tree_map.insert(
             vec![0],
-            PMCFGRule::from_str(
-                "A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1",
-            ).unwrap(),
+            PMCFGRule::from_str("A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1")
+                .unwrap(),
         );
         tree_map.insert(
             vec![0, 0],
-            PMCFGRule::from_str(
-                "A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1",
-            ).unwrap(),
+            PMCFGRule::from_str("A -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (A, a, c) # 1")
+                .unwrap(),
         );
         tree_map.insert(
             vec![0, 0, 0],
@@ -580,9 +588,8 @@ mod tests {
         );
         tree_map.insert(
             vec![1],
-            PMCFGRule::from_str(
-                "B -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (B, b, d) # 1",
-            ).unwrap(),
+            PMCFGRule::from_str("B -> [[Var 1 0, Var 0 0], [Var 2 0, Var 0 1]] (B, b, d) # 1")
+                .unwrap(),
         );
         tree_map.insert(
             vec![1, 0],
@@ -605,33 +612,35 @@ mod tests {
         let tree_map = example_tree_map();
         let mut term_map = GornTree::new();
 
-        for (address,
-             PMCFGRule {
-                 head: _,
-                 tail: _,
-                 composition,
-                 weight: _,
-             }) in tree_map
+        for (
+            address,
+            PMCFGRule {
+                head: _,
+                tail: _,
+                composition,
+                weight: _,
+            },
+        ) in tree_map
         {
             term_map.insert(address, composition);
         }
 
-        let expanded_compos = Composition::from(vec![
-            vec![
-                T(String::from("a")),
-                T(String::from("a")),
-                T(String::from("b")),
-                T(String::from("c")),
-                T(String::from("c")),
-                T(String::from("d")),
-            ],
-        ]);
+        let expanded_compos = Composition::from(vec![vec![
+            T(String::from("a")),
+            T(String::from("a")),
+            T(String::from("b")),
+            T(String::from("c")),
+            T(String::from("c")),
+            T(String::from("d")),
+        ]]);
 
         assert_eq!(expanded_compos, evaluate(&term_map));
     }
 
     #[test]
-    #[should_panic(expected = "[[Var 0 0, Var 0 1]]: use of 1-th component of nonterminal 0 that has only 1 components!")]
+    #[should_panic(
+        expected = "[[Var 0 0, Var 0 1]]: use of 1-th component of nonterminal 0 that has only 1 components!"
+    )]
     fn test_evaluate_invalid_composition() {
         let mut term_map = GornTree::new();
         term_map.insert(vec![], Composition::from(vec![vec![Var(0, 0), Var(0, 1)]]));
@@ -733,9 +742,8 @@ mod tests {
         let mut separated_control_map = GornTree::new();
         separated_control_map.insert(
             vec![],
-            PMCFGRule::from_str(
-                "S -> [[Var 0 0, Var 2 0, Var 1 0, Var 3 0]] (A, B, b, d) # 1",
-            ).unwrap(),
+            PMCFGRule::from_str("S -> [[Var 0 0, Var 2 0, Var 1 0, Var 3 0]] (A, B, b, d) # 1")
+                .unwrap(),
         );
         separated_control_map.insert(
             vec![0],
@@ -754,10 +762,10 @@ mod tests {
         separated_control_map.insert(vec![3], PMCFGRule::from_str("d -> [[T d]] () # 1").unwrap());
 
         for (ref address, ref rule) in separate_terminal_rules(&tree_map) {
-            assert_eq!((address, separated_control_map.get(address).unwrap()), (
-                address,
-                rule,
-            ));
+            assert_eq!(
+                (address, separated_control_map.get(address).unwrap()),
+                (address, rule,)
+            );
         }
     }
 
@@ -791,9 +799,8 @@ mod tests {
         let mut separated_control_map = GornTree::new();
         separated_control_map.insert(
             vec![],
-            PMCFGRule::from_str(
-                "S -> [[Var 0 0, Var 2 0, Var 1 0, Var 3 0]] (a, b, aa, bbb) # 1",
-            ).unwrap(),
+            PMCFGRule::from_str("S -> [[Var 0 0, Var 2 0, Var 1 0, Var 3 0]] (a, b, aa, bbb) # 1")
+                .unwrap(),
         );
         separated_control_map.insert(vec![0], PMCFGRule::from_str("a -> [[T b]] () # 1").unwrap());
         separated_control_map.insert(
@@ -814,10 +821,10 @@ mod tests {
         );
 
         for (ref address, ref rule) in separate_terminal_rules(&tree_map) {
-            assert_eq!((address, separated_control_map.get(address).unwrap()), (
-                address,
-                rule,
-            ));
+            assert_eq!(
+                (address, separated_control_map.get(address).unwrap()),
+                (address, rule,)
+            );
         }
     }
 }

--- a/src/grammars/pmcfg/mod.rs
+++ b/src/grammars/pmcfg/mod.rs
@@ -5,8 +5,8 @@ use std::iter::Extend;
 use std::slice;
 use std::vec;
 
-use util::tree::GornTree;
-use grammars::mcfg::Mcfg;
+use crate::util::tree::GornTree;
+use crate::grammars::mcfg::Mcfg;
 
 mod from_str;
 pub mod negra;

--- a/src/grammars/pmcfg/negra.rs
+++ b/src/grammars/pmcfg/negra.rs
@@ -70,12 +70,16 @@ where
 #[derive(Clone, Debug)]
 pub enum DumpMode<T> {
     FromPos(Vec<T>),
-    Default
+    Default,
 }
 
 /// Takes a tree stack _(encoded in a Gorn tree)_ of PMCFG rules and transforms it into a
 /// corresponding _NEGRA_ string.
-pub fn to_negra<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>, sentence_id: usize, mode: DumpMode<T>) -> String
+pub fn to_negra<H, T, W>(
+    tree_map: &GornTree<PMCFGRule<H, T, W>>,
+    sentence_id: usize,
+    mode: DumpMode<T>,
+) -> String
 where
     H: Clone + ToString,
     T: Clone + ToString,
@@ -83,7 +87,7 @@ where
     if !meets_negra_criteria(&tree_map) {
         panic!(
             "The given tree does not meet the negra criteria! All rules must either consist \
-                only of nonterminals or of exactly one terminal symbol."
+             only of nonterminals or of exactly one terminal symbol."
         );
     }
 
@@ -100,12 +104,16 @@ where
 
 pub fn noparse<T>(sentence: &[T], sentence_id: usize, mode: DumpMode<T>) -> String
 where
-    T: ToString
+    T: ToString,
 {
     let mut output = format!("#BOS {}\n", sentence_id);
-    if  let DumpMode::FromPos(poss) = mode {
+    if let DumpMode::FromPos(poss) = mode {
         for (pos, word) in sentence.iter().zip(&poss) {
-            output.push_str(&format!("{}\t{}\t--\t--\t500\n", word.to_string(), pos.to_string()));
+            output.push_str(&format!(
+                "{}\t{}\t--\t--\t500\n",
+                word.to_string(),
+                pos.to_string()
+            ));
         }
     } else {
         for word in sentence.iter() {
@@ -152,7 +160,10 @@ pub fn meets_negra_criteria<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>) ->
     true
 }
 
-fn to_negra_vector<H, T, W>(tree_map: &GornTree<PMCFGRule<H, T, W>>, mut mode: DumpMode<T>) -> Vec<(String, String, usize)>
+fn to_negra_vector<H, T, W>(
+    tree_map: &GornTree<PMCFGRule<H, T, W>>,
+    mut mode: DumpMode<T>,
+) -> Vec<(String, String, usize)>
 where
     H: Clone + ToString,
     T: Clone + ToString,
@@ -178,7 +189,7 @@ where
                     } else {
                         terminal_map.get(&terminal_id).unwrap().to_string()
                     };
-                    
+
                     let address = terminal_id.address;
                     let rule_label = nonterminal_map.get(&address).unwrap();
 
@@ -193,11 +204,7 @@ where
                             &mut rule_counter,
                         )
                     };
-                    negra_vector.push((
-                        terminal_string,
-                        rule_label.to_string(),
-                        parent_number,
-                    ));
+                    negra_vector.push((terminal_string, rule_label.to_string(), parent_number));
                 }
             }
         }
@@ -249,9 +256,9 @@ fn get_rule_number(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use super::super::tests::*;
     use self::VarT::{Var, T};
+    use super::super::tests::*;
+    use super::*;
     use std::str::FromStr;
 
     #[test]
@@ -270,20 +277,16 @@ mod tests {
         let mut identified_tree_map = GornTree::new();
         identified_tree_map.insert(
             vec![],
-            Composition::from(vec![
-                vec![
-                    Var(0, 0),
-                    T(TermId::from((vec![], 1))),
-                    Var(0, 1),
-                    T(TermId::from((vec![], 3))),
-                ],
-            ]),
+            Composition::from(vec![vec![
+                Var(0, 0),
+                T(TermId::from((vec![], 1))),
+                Var(0, 1),
+                T(TermId::from((vec![], 3))),
+            ]]),
         );
         identified_tree_map.insert(
             vec![0],
-            Composition::from(
-                vec![vec![Var(1, 0)], vec![T(TermId::from((vec![0], 1)))]],
-            ),
+            Composition::from(vec![vec![Var(1, 0)], vec![T(TermId::from((vec![0], 1)))]]),
         );
         identified_tree_map.insert(
             vec![0, 1],
@@ -320,12 +323,8 @@ mod tests {
                             unidentified_compon.push(VarT::Var(x, y));
                         }
                         VarT::T(terminal_id) => {
-                            unidentified_compon.push(VarT::T(
-                                terminal_map
-                                    .get(&terminal_id)
-                                    .unwrap()
-                                    .clone(),
-                            ));
+                            unidentified_compon
+                                .push(VarT::T(terminal_map.get(&terminal_id).unwrap().clone()));
                         }
                     }
                 }
@@ -373,12 +372,17 @@ mod tests {
         ];
 
         assert_eq!(
-            negra_vector, 
+            negra_vector,
             to_negra_vector(
                 &tree_map,
-                DumpMode::FromPos(
-                    vec!["Ah".to_string(), "Ah".to_string(), "Beh".to_string(), "Zeh".to_string(), "Zeh".to_string(), "Deh".to_string()]
-                )
+                DumpMode::FromPos(vec![
+                    "Ah".to_string(),
+                    "Ah".to_string(),
+                    "Beh".to_string(),
+                    "Zeh".to_string(),
+                    "Zeh".to_string(),
+                    "Deh".to_string()
+                ])
             )
         );
     }
@@ -410,8 +414,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "The given tree does not meet the negra criteria! All rules must either consist \
-         only of nonterminals or of exactly one terminal symbol.")]
+    #[should_panic(
+        expected = "The given tree does not meet the negra criteria! All rules must either consist \
+         only of nonterminals or of exactly one terminal symbol."
+    )]
     fn test_to_negra_violated_criteria() {
         let mut tree_map: GornTree<PMCFGRule<String, char, usize>> = GornTree::new();
         tree_map.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,15 @@ extern crate log_domain;
 #[macro_use]
 extern crate nom;
 extern crate num_traits;
-extern crate time;
 extern crate rand;
 extern crate serde;
+extern crate time;
 #[macro_use]
 extern crate serde_derive;
 extern crate fnv;
+extern crate search;
 extern crate unique_heap;
 extern crate vecmultimap;
-extern crate search;
 
 pub mod approximation;
 pub mod automata;

--- a/src/recognisable/automaton.rs
+++ b/src/recognisable/automaton.rs
@@ -1,9 +1,14 @@
-use std::{ collections::{BinaryHeap, HashMap}, hash::Hash, ops::MulAssign, rc::Rc };
 use num_traits::One;
+use std::{
+    collections::{BinaryHeap, HashMap},
+    hash::Hash,
+    ops::MulAssign,
+    rc::Rc,
+};
 
 use crate::recognisable::{Configuration, Instruction, Item, Transition};
-use crate::util::{  push_down::Pushdown };
-use search::{Search, agenda::limited_heap::weighted::LimitedHeap, Agenda };
+use crate::util::push_down::Pushdown;
+use search::{agenda::limited_heap::weighted::LimitedHeap, Agenda, Search};
 
 // map from key to transition
 pub type TransitionMap<K, I, T, W> = HashMap<K, BinaryHeap<Transition<I, T, W>>>;
@@ -37,7 +42,6 @@ where
     /// The internal representation of the terminal symbols
     type TInt;
 
-
     /// Builds an `Automaton` from transitions and an initial storage configuration.
     fn from_transitions<It>(transitions: It, initial: <Self::I as Instruction>::Storage) -> Self
     where
@@ -45,7 +49,6 @@ where
 
     /// Returns a boxed `Iterator` over the `Transitions` of this `Automaton`.
     fn transitions<'a>(&'a self) -> Box<Iterator<Item = Transition<Self::I, T, W>> + 'a>;
-
 
     /// Returns the initial storage configuration.
     fn initial(&self) -> <Self::I as Instruction>::Storage;
@@ -58,7 +61,6 @@ where
 
     /// Translates a terminal symbol to its internal representation.
     fn terminal_to_int(&self, t: &T) -> Option<Self::TInt>;
-
 
     /// Returns the `Self::Key` for the given `Configuration` (in its internal representation).
     fn extract_key(
@@ -110,7 +112,6 @@ where
     }
 }
 
-
 pub fn recognise<'a, A, T, W>(
     a: &'a A,
     word: Vec<T>,
@@ -146,15 +147,15 @@ where
         rules
             .iter()
             .flat_map(|r| {
-                r.apply(conf).into_iter().map(move |conf1| {
-                    Item(conf1, run.clone().push(r.clone()))
-                })
+                r.apply(conf)
+                    .into_iter()
+                    .map(move |conf1| Item(conf1, run.clone().push(r.clone())))
             })
             .collect::<Vec<_>>()
-    }).filter(move |Item(c, _)| a.is_terminal(c))
-        .map(move |i| a.item_map(&i))
+    })
+    .filter(move |Item(c, _)| a.is_terminal(c))
+    .map(move |i| a.item_map(&i))
 }
-
 
 pub fn recognise_beam<'a, A, T, W>(
     a: &'a A,
@@ -195,11 +196,12 @@ where
         rules
             .iter()
             .flat_map(|r| {
-                r.apply(conf).into_iter().map(move |conf1| {
-                    Item(conf1, run.clone().push(r.clone()))
-                })
+                r.apply(conf)
+                    .into_iter()
+                    .map(move |conf1| Item(conf1, run.clone().push(r.clone())))
             })
             .collect::<Vec<_>>()
-    }).filter(move |Item(c, _)| a.is_terminal(c))
-        .map(move |i| a.item_map(&i))
+    })
+    .filter(move |Item(c, _)| a.is_terminal(c))
+    .map(move |i| a.item_map(&i))
 }

--- a/src/recognisable/automaton.rs
+++ b/src/recognisable/automaton.rs
@@ -1,8 +1,8 @@
 use std::{ collections::{BinaryHeap, HashMap}, hash::Hash, ops::MulAssign, rc::Rc };
 use num_traits::One;
 
-use recognisable::{Configuration, Instruction, Item, Transition};
-use util::{  push_down::Pushdown };
+use crate::recognisable::{Configuration, Instruction, Item, Transition};
+use crate::util::{  push_down::Pushdown };
 use search::{Search, agenda::limited_heap::weighted::LimitedHeap, Agenda };
 
 // map from key to transition

--- a/src/recognisable/coarse_to_fine.rs
+++ b/src/recognisable/coarse_to_fine.rs
@@ -4,18 +4,23 @@ use std::ops::MulAssign;
 use std::rc::Rc;
 
 use crate::approximation::{ApproximationInstance, ApproximationStrategy};
-use crate::recognisable::{Instruction, Item, Recognisable};
 use crate::recognisable::automaton::Automaton;
+use crate::recognisable::{Instruction, Item, Recognisable};
 use search::agenda::weighted::Weighted;
 
 pub struct CoarseToFineRecogniser<Rec, SubRec, Strategy, T, W>
-    where Rec: Automaton<T, W>,
-          SubRec: Recognisable<T, W, Parse=Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>>,
-          Strategy: ApproximationStrategy<T, W> + Sized,
-          Strategy::I1: Instruction,
-          Strategy::I2: Instruction,
-          T: Clone + Eq + Ord,
-          W: Clone + MulAssign + One + Ord,
+where
+    Rec: Automaton<T, W>,
+    SubRec: Recognisable<
+        T,
+        W,
+        Parse = Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>,
+    >,
+    Strategy: ApproximationStrategy<T, W> + Sized,
+    Strategy::I1: Instruction,
+    Strategy::I2: Instruction,
+    T: Clone + Eq + Ord,
+    W: Clone + MulAssign + One + Ord,
 {
     pub recogniser: Rc<Rec>,
     pub sublevel: Rc<SubRec>,
@@ -39,13 +44,16 @@ where
 }
 
 impl<'a, Rec, Strategy, T, W> CoarseToFineParseForest<'a, Rec, Strategy, T, W>
-    where Rec: Automaton<T, W>,
-          Strategy: 'a + ApproximationStrategy<T, W>,
-          Strategy::I1: Instruction,
-          T: 'a + Clone + Eq + Ord,
-          W: 'a + Clone + MulAssign + One + Ord,
+where
+    Rec: Automaton<T, W>,
+    Strategy: 'a + ApproximationStrategy<T, W>,
+    Strategy::I1: Instruction,
+    T: 'a + Clone + Eq + Ord,
+    W: 'a + Clone + MulAssign + One + Ord,
 {
-    fn peek_input(&mut self) -> Option<&Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>> {
+    fn peek_input(
+        &mut self,
+    ) -> Option<&Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>> {
         if self.input_buffer.is_none() {
             self.input_buffer = Some(self.sublevel_parses.next());
         }
@@ -56,7 +64,9 @@ impl<'a, Rec, Strategy, T, W> CoarseToFineParseForest<'a, Rec, Strategy, T, W>
         }
     }
 
-    fn next_input(&mut self) -> Option<Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>> {
+    fn next_input(
+        &mut self,
+    ) -> Option<Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>> {
         if self.input_buffer.is_none() {
             self.input_buffer = Some(self.sublevel_parses.next());
         }
@@ -68,19 +78,21 @@ impl<'a, Rec, Strategy, T, W> CoarseToFineParseForest<'a, Rec, Strategy, T, W>
 }
 
 impl<'a, Rec, Strategy, T, W> Iterator for CoarseToFineParseForest<'a, Rec, Strategy, T, W>
-    where Rec: Automaton<T, W, I=Strategy::I1>,
-          Strategy: ApproximationStrategy<T, W>,
-          Strategy::I1: Instruction + Ord,
-          <Strategy::I1 as Instruction>::Storage: Ord,
-          T: Clone + Eq + Ord,
-          W: Clone + MulAssign + One + Ord,
+where
+    Rec: Automaton<T, W, I = Strategy::I1>,
+    Strategy: ApproximationStrategy<T, W>,
+    Strategy::I1: Instruction + Ord,
+    <Strategy::I1 as Instruction>::Storage: Ord,
+    T: Clone + Eq + Ord,
+    W: Clone + MulAssign + One + Ord,
 {
     type Item = Item<<Strategy::I1 as Instruction>::Storage, Strategy::I1, T, W>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.output_buffer.is_empty()
             || self.peek_input().is_some()
-            && self.output_buffer.peek().unwrap().get_weight() < self.peek_input().unwrap().get_weight()
+                && self.output_buffer.peek().unwrap().get_weight()
+                    < self.peek_input().unwrap().get_weight()
         {
             if let Some(Item(_, r2)) = self.next_input() {
                 let r1s = self.approximation_instance.unapproximate_run(r2);
@@ -101,7 +113,11 @@ impl<Rec, SubRec, Strategy, T, W> Recognisable<T, W>
     for CoarseToFineRecogniser<Rec, SubRec, Strategy, T, W>
 where
     Rec: Automaton<T, W, I = Strategy::I1>,
-    SubRec: Recognisable<T, W, Parse = Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>>,
+    SubRec: Recognisable<
+        T,
+        W,
+        Parse = Item<<Strategy::I2 as Instruction>::Storage, Strategy::I2, T, W>,
+    >,
     Strategy: ApproximationStrategy<T, W>,
     Strategy::I1: Instruction + Ord,
     <Strategy::I1 as Instruction>::Storage: Ord,

--- a/src/recognisable/coarse_to_fine.rs
+++ b/src/recognisable/coarse_to_fine.rs
@@ -3,9 +3,9 @@ use std::collections::BinaryHeap;
 use std::ops::MulAssign;
 use std::rc::Rc;
 
-use approximation::{ApproximationInstance, ApproximationStrategy};
-use recognisable::{Instruction, Item, Recognisable};
-use recognisable::automaton::Automaton;
+use crate::approximation::{ApproximationInstance, ApproximationStrategy};
+use crate::recognisable::{Instruction, Item, Recognisable};
+use crate::recognisable::automaton::Automaton;
 use search::agenda::weighted::Weighted;
 
 pub struct CoarseToFineRecogniser<Rec, SubRec, Strategy, T, W>

--- a/src/recognisable/configuration.rs
+++ b/src/recognisable/configuration.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 /// Configuration of an automaton containing sequence of symbols `word` to be read, a storage value `storage`, and a `weight`.
 #[derive(Clone, Debug)]
@@ -34,20 +34,13 @@ where
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.weight.partial_cmp(&other.weight) {
-            None |
-            Some(Ordering::Equal) => {
-                match other.word.len().partial_cmp(&self.word.len()) {
-                    None |
-                    Some(Ordering::Equal) => {
-                        match self.word.partial_cmp(&other.word) {
-                            None |
-                            Some(Ordering::Equal) => self.storage.partial_cmp(&other.storage),
-                            x => x,
-                        }
-                    }
+            None | Some(Ordering::Equal) => match other.word.len().partial_cmp(&self.word.len()) {
+                None | Some(Ordering::Equal) => match self.word.partial_cmp(&other.word) {
+                    None | Some(Ordering::Equal) => self.storage.partial_cmp(&other.storage),
                     x => x,
-                }
-            }
+                },
+                x => x,
+            },
             x => x,
         }
     }
@@ -61,17 +54,13 @@ where
 {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.weight.cmp(&other.weight) {
-            Ordering::Equal => {
-                match other.word.len().cmp(&self.word.len()) {
-                    Ordering::Equal => {
-                        match self.word.cmp(&other.word) {
-                            Ordering::Equal => self.storage.cmp(&other.storage),
-                            x => x,
-                        }
-                    }
+            Ordering::Equal => match other.word.len().cmp(&self.word.len()) {
+                Ordering::Equal => match self.word.cmp(&other.word) {
+                    Ordering::Equal => self.storage.cmp(&other.storage),
                     x => x,
-                }
-            }
+                },
+                x => x,
+            },
             x => x,
         }
     }
@@ -91,9 +80,7 @@ impl<S: fmt::Display, T: fmt::Display, W: fmt::Display> fmt::Display for Configu
         write!(
             f,
             "Configuration:\nword:[{}]\nweight:{}\n{}\n",
-            buffer,
-            self.weight,
-            self.storage
+            buffer, self.weight, self.storage
         )
     }
 }

--- a/src/recognisable/from_str.rs
+++ b/src/recognisable/from_str.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 use std::vec::Vec;
 use std::str::{FromStr, from_utf8};
 
-use recognisable::{Instruction, Transition};
-use util::parsing::{parse_comment, parse_token, parse_vec};
+use crate::recognisable::{Instruction, Transition};
+use crate::util::parsing::{parse_comment, parse_token, parse_vec};
 
 
 impl<I: Instruction + FromStr, T: FromStr, W: FromStr> FromStr for Transition<I, T, W>

--- a/src/recognisable/from_str.rs
+++ b/src/recognisable/from_str.rs
@@ -1,15 +1,15 @@
-use nom::{IResult, is_space};
+use nom::{is_space, IResult};
 use num_traits::One;
 use std::fmt::Debug;
+use std::str::{from_utf8, FromStr};
 use std::vec::Vec;
-use std::str::{FromStr, from_utf8};
 
 use crate::recognisable::{Instruction, Transition};
 use crate::util::parsing::{parse_comment, parse_token, parse_vec};
 
-
 impl<I: Instruction + FromStr, T: FromStr, W: FromStr> FromStr for Transition<I, T, W>
-    where I: FromStr,
+where
+    I: FromStr,
     I::Err: Debug,
     T: FromStr,
     T::Err: Debug,
@@ -21,7 +21,7 @@ impl<I: Instruction + FromStr, T: FromStr, W: FromStr> FromStr for Transition<I,
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match parse_transition(s.as_bytes()) {
             IResult::Done(_, result) => Ok(result),
-            _                        => Err(format!("Could not parse: {}", s)),
+            _ => Err(format!("Could not parse: {}", s)),
         }
     }
 }
@@ -37,25 +37,26 @@ where
 {
     do_parse!(
         input,
-        tag!("Transition") >>
-            take_while!(is_space) >>
-            word: parse_word >>
-            take_while!(is_space) >>
-            instruction: map_res!(delimited!(tag!("("), take_until!(")"), tag!(")")), from_utf8) >>
-            take_while!(is_space) >>
-            weight_o: opt!(
-                complete!(
-                    do_parse!(
-                        tag!("#") >>
-                            take_while!(is_space) >>
-                            weight_s: map_res!(is_not!(" "), from_utf8) >>
-                            (weight_s.parse().unwrap())
-                    )
+        tag!("Transition")
+            >> take_while!(is_space)
+            >> word: parse_word
+            >> take_while!(is_space)
+            >> instruction:
+                map_res!(
+                    delimited!(tag!("("), take_until!(")"), tag!(")")),
+                    from_utf8
                 )
-            ) >>
-            take_while!(is_space) >>
-            opt!(complete!(parse_comment)) >>
-            (Transition {
+            >> take_while!(is_space)
+            >> weight_o:
+                opt!(complete!(do_parse!(
+                    tag!("#")
+                        >> take_while!(is_space)
+                        >> weight_s: map_res!(is_not!(" "), from_utf8)
+                        >> (weight_s.parse().unwrap())
+                )))
+            >> take_while!(is_space)
+            >> opt!(complete!(parse_comment))
+            >> (Transition {
                 word: word,
                 weight: weight_o.unwrap_or(W::one()),
                 instruction: instruction.parse().unwrap(),
@@ -78,17 +79,17 @@ fn test_parse_word() {
         (
             "[a, b, c]",
             "",
-            vec![String::from("a"), String::from("b"), String::from("c")]
+            vec![String::from("a"), String::from("b"), String::from("c")],
         ),
         (
             "[xyz, ab]",
             "",
-            vec![String::from("xyz"), String::from("ab")]
+            vec![String::from("xyz"), String::from("ab")],
         ),
         (
             "[\"xyz\", \"ab\", cd] bla",
             " bla",
-            vec![String::from("xyz"), String::from("ab"), String::from("cd")]
+            vec![String::from("xyz"), String::from("ab"), String::from("cd")],
         ),
     ];
 
@@ -110,7 +111,7 @@ fn test_parse_transitions() {
                 word: vec![1usize, 2usize, 3usize],
                 weight: 2usize,
                 instruction: 1usize,
-            }
+            },
         ),
         (
             "Transition [1, 2, 3] (1) % blub",
@@ -119,7 +120,7 @@ fn test_parse_transitions() {
                 word: vec![1usize, 2usize, 3usize],
                 weight: 1usize,
                 instruction: 1usize,
-            }
+            },
         ),
         (
             "Transition [1, 2, 3] (1)",
@@ -128,7 +129,7 @@ fn test_parse_transitions() {
                 word: vec![1usize, 2usize, 3usize],
                 weight: 1usize,
                 instruction: 1usize,
-            }
+            },
         ),
     ];
 

--- a/src/recognisable/mod.rs
+++ b/src/recognisable/mod.rs
@@ -6,13 +6,12 @@ pub mod from_str;
 #[macro_use]
 pub mod coarse_to_fine;
 
-use std::vec::Vec;
-use search::agenda::weighted::Weighted;
 use crate::util::push_down::Pushdown;
+use search::agenda::weighted::Weighted;
+use std::vec::Vec;
 
 pub use self::configuration::Configuration;
 pub use self::transition::Transition;
-
 
 /// Something we can `apply` to a configuration.
 pub trait Instruction {
@@ -21,10 +20,12 @@ pub trait Instruction {
     fn apply(&self, _: Self::Storage) -> Vec<Self::Storage>;
 }
 
-
 /// items of the transition system
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Item<S, I, T, W>(pub Configuration<S, T, W>, pub Pushdown<Transition<I, T, W>>);
+pub struct Item<S, I, T, W>(
+    pub Configuration<S, T, W>,
+    pub Pushdown<Transition<I, T, W>>,
+);
 pub type VecItem<S, I, T, W> = (Configuration<S, T, W>, Vec<Transition<I, T, W>>);
 
 impl<S, I: Instruction<Storage = S>, T, W: Clone> Weighted for Item<S, I, T, W> {
@@ -34,8 +35,6 @@ impl<S, I: Instruction<Storage = S>, T, W: Clone> Weighted for Item<S, I, T, W> 
         self.0.weight.clone()
     }
 }
-
-
 
 /// Something that recognises words and output corresponding parses.
 pub trait Recognisable<T, W> {

--- a/src/recognisable/mod.rs
+++ b/src/recognisable/mod.rs
@@ -8,7 +8,7 @@ pub mod coarse_to_fine;
 
 use std::vec::Vec;
 use search::agenda::weighted::Weighted;
-use util::push_down::Pushdown;
+use crate::util::push_down::Pushdown;
 
 pub use self::configuration::Configuration;
 pub use self::transition::Transition;
@@ -18,7 +18,7 @@ pub use self::transition::Transition;
 pub trait Instruction {
     type Storage;
 
-    fn apply(&self, Self::Storage) -> Vec<Self::Storage>;
+    fn apply(&self, _: Self::Storage) -> Vec<Self::Storage>;
 }
 
 

--- a/src/recognisable/transition.rs
+++ b/src/recognisable/transition.rs
@@ -5,8 +5,8 @@ use std::hash::{Hash, Hasher};
 
 use integeriser::{HashIntegeriser, Integeriser};
 
-use recognisable::{Configuration, Instruction};
-use util::integerisable::{Integerisable1, Integerisable2};
+use crate::recognisable::{Configuration, Instruction};
+use crate::util::integerisable::{Integerisable1, Integerisable2};
 
 /// Transition of an automaton with `weight`, reading the sequence `word`, and applying the `instruction`.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/recognisable/transition.rs
+++ b/src/recognisable/transition.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
-use std::ops::Mul;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
+use std::ops::Mul;
 
 use integeriser::{HashIntegeriser, Integeriser};
 
@@ -28,7 +28,8 @@ where
 
     fn integerise(&self, integeriser1: &mut Self::I1, integeriser2: &mut Self::I2) -> Self::AInt {
         Transition {
-            word: self.word
+            word: self
+                .word
                 .iter()
                 .map(|t| integeriser1.integerise(t.clone()))
                 .collect(),
@@ -39,7 +40,8 @@ where
 
     fn un_integerise(v: &Self::AInt, integeriser1: &Self::I1, integeriser2: &Self::I2) -> Self {
         Transition {
-            word: v.word
+            word: v
+                .word
                 .iter()
                 .map(|i| integeriser1.find_value(*i).unwrap().clone())
                 .collect(),
@@ -114,14 +116,10 @@ where
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.weight.partial_cmp(&other.weight) {
-            None |
-            Some(Ordering::Equal) => {
-                match self.word.partial_cmp(&other.word) {
-                    None |
-                    Some(Ordering::Equal) => self.instruction.partial_cmp(&other.instruction),
-                    x => x,
-                }
-            }
+            None | Some(Ordering::Equal) => match self.word.partial_cmp(&other.word) {
+                None | Some(Ordering::Equal) => self.instruction.partial_cmp(&other.instruction),
+                x => x,
+            },
             x => x,
         }
     }
@@ -135,12 +133,10 @@ where
 {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.weight.cmp(&other.weight) {
-            Ordering::Equal => {
-                match self.word.cmp(&other.word) {
-                    Ordering::Equal => self.instruction.cmp(&other.instruction),
-                    x => x,
-                }
-            }
+            Ordering::Equal => match self.word.cmp(&other.word) {
+                Ordering::Equal => self.instruction.cmp(&other.instruction),
+                x => x,
+            },
             x => x,
         }
     }
@@ -156,9 +152,7 @@ where
         write!(
             f,
             "Transition {:?} {}  # {}",
-            self.word,
-            self.instruction,
-            self.weight
+            self.word, self.instruction, self.weight
         )
     }
 }

--- a/src/util/factorizable.rs
+++ b/src/util/factorizable.rs
@@ -1,10 +1,9 @@
 use log_domain::LogDomain;
-use std::{ iter::repeat, marker::Sized };
-
+use std::{iter::repeat, marker::Sized};
 
 pub trait Factorizable
 where
-    Self: Sized
+    Self: Sized,
 {
     fn factorize(self, n: usize) -> Vec<Self>;
 }

--- a/src/util/integerisable.rs
+++ b/src/util/integerisable.rs
@@ -11,7 +11,7 @@ where
 
     fn integerise(&self, integeriser: &mut Self::I) -> Self::AInt;
 
-    fn un_integerise(&Self::AInt, integeriser: &Self::I) -> Self;
+    fn un_integerise(_: &Self::AInt, integeriser: &Self::I) -> Self;
 }
 
 pub trait Integerisable2
@@ -28,5 +28,5 @@ where
 
     fn integerise(&self, integeriser1: &mut Self::I1, integeriser2: &mut Self::I2) -> Self::AInt;
 
-    fn un_integerise(&Self::AInt, integeriser1: &Self::I1, integeriser2: &Self::I2) -> Self;
+    fn un_integerise(_: &Self::AInt, integeriser1: &Self::I1, integeriser2: &Self::I2) -> Self;
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,10 +1,10 @@
-pub mod partition;
-pub mod push_down;
+pub mod factorizable;
 pub mod integerisable;
 pub mod parsing;
+pub mod partition;
+pub mod push_down;
 pub mod reverse;
 pub mod tree;
-pub mod factorizable;
 
 use fnv::{FnvHashMap, FnvHashSet};
 

--- a/src/util/partition.rs
+++ b/src/util/partition.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeSet, BTreeMap};
 use std::collections::btree_map::Keys;
-use std::rc::Rc;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
+use std::rc::Rc;
 
-use serde::ser::{Serialize, Serializer};
 use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
 
 /// A partition Π = {π₁, …, πₙ} of an alpbabet Σ, such that
 /// πᵢ ⊆ Σ for each i ∈ [n] and π₁ ∪ … ∪ πₙ = Σ.
@@ -81,7 +81,6 @@ impl<'de, T: Deserialize<'de> + Ord + Clone> Deserialize<'de> for Partition<T> {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/util/push_down.rs
+++ b/src/util/push_down.rs
@@ -3,8 +3,8 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::vec::IntoIter;
 
-use integeriser::{HashIntegeriser, Integeriser};
 use crate::util::integerisable::Integerisable1;
+use integeriser::{HashIntegeriser, Integeriser};
 
 #[derive(Debug, Clone, PartialOrd, Ord)]
 pub enum Pushdown<A> {
@@ -16,14 +16,16 @@ impl<A: PartialEq> PartialEq for Pushdown<A> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (&Pushdown::Empty, &Pushdown::Empty) => true,
-            (&Pushdown::Cons {
-                 value: ref a1,
-                 below: ref b1,
-             },
-             &Pushdown::Cons {
-                 value: ref a2,
-                 below: ref b2,
-             }) => a1 == a2 && (Rc::ptr_eq(b1, b2) || b1 == b2),
+            (
+                &Pushdown::Cons {
+                    value: ref a1,
+                    below: ref b1,
+                },
+                &Pushdown::Cons {
+                    value: ref a2,
+                    below: ref b2,
+                },
+            ) => a1 == a2 && (Rc::ptr_eq(b1, b2) || b1 == b2),
             _ => false,
         }
     }

--- a/src/util/push_down.rs
+++ b/src/util/push_down.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::vec::IntoIter;
 
 use integeriser::{HashIntegeriser, Integeriser};
-use util::integerisable::Integerisable1;
+use crate::util::integerisable::Integerisable1;
 
 #[derive(Debug, Clone, PartialOrd, Ord)]
 pub enum Pushdown<A> {

--- a/src/util/reverse.rs
+++ b/src/util/reverse.rs
@@ -1,37 +1,44 @@
+use super::factorizable::Factorizable;
 use num_traits::{One, Zero};
 use std::cmp::Ordering;
 use std::fmt::{Display, Error, Formatter};
-use std::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign, Rem, RemAssign};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
 use std::str::FromStr;
-use super::factorizable::Factorizable;
-
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Reverse<W>(W);
 
 impl<W> PartialOrd for Reverse<W>
-where W: PartialOrd {
+where
+    W: PartialOrd,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
     }
 }
 
 impl<W> Ord for Reverse<W>
-where W: Ord {
+where
+    W: Ord,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         other.0.cmp(&self.0)
     }
 }
 
 impl<W> Display for Reverse<W>
-where W: Display {
+where
+    W: Display,
+{
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         self.0.fmt(f)
     }
 }
 
 impl<W> FromStr for Reverse<W>
-where W: FromStr {
+where
+    W: FromStr,
+{
     type Err = W::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -40,7 +47,9 @@ where W: FromStr {
 }
 
 impl<W> Zero for Reverse<W>
-where W: Zero {
+where
+    W: Zero,
+{
     fn zero() -> Self {
         Reverse(W::zero())
     }
@@ -51,14 +60,18 @@ where W: Zero {
 }
 
 impl<W> One for Reverse<W>
-where W: One {
+where
+    W: One,
+{
     fn one() -> Self {
         Reverse(W::one())
     }
 }
 
 impl<W> Add for Reverse<W>
-where W: Add {
+where
+    W: Add,
+{
     type Output = Reverse<W::Output>;
     fn add(self, other: Self) -> Self::Output {
         Reverse(self.0.add(other.0))
@@ -66,14 +79,18 @@ where W: Add {
 }
 
 impl<W> AddAssign for Reverse<W>
-where W: AddAssign {
+where
+    W: AddAssign,
+{
     fn add_assign(&mut self, other: Self) {
         self.0.add_assign(other.0)
     }
 }
 
 impl<W> Sub for Reverse<W>
-where W: Sub {
+where
+    W: Sub,
+{
     type Output = Reverse<W::Output>;
     fn sub(self, other: Self) -> Self::Output {
         Reverse(self.0.sub(other.0))
@@ -81,14 +98,18 @@ where W: Sub {
 }
 
 impl<W> SubAssign for Reverse<W>
-where W: SubAssign {
+where
+    W: SubAssign,
+{
     fn sub_assign(&mut self, other: Self) {
         self.0.sub_assign(other.0)
     }
 }
 
 impl<W> Mul for Reverse<W>
-where W: Mul {
+where
+    W: Mul,
+{
     type Output = Reverse<W::Output>;
     fn mul(self, other: Self) -> Self::Output {
         Reverse(self.0.mul(other.0))
@@ -96,14 +117,18 @@ where W: Mul {
 }
 
 impl<W> MulAssign for Reverse<W>
-where W: MulAssign {
+where
+    W: MulAssign,
+{
     fn mul_assign(&mut self, other: Self) {
         self.0.mul_assign(other.0)
     }
 }
 
 impl<W> Div for Reverse<W>
-where W: Div {
+where
+    W: Div,
+{
     type Output = Reverse<W::Output>;
     fn div(self, other: Self) -> Self::Output {
         Reverse(self.0.div(other.0))
@@ -111,14 +136,18 @@ where W: Div {
 }
 
 impl<W> DivAssign for Reverse<W>
-where W: DivAssign {
+where
+    W: DivAssign,
+{
     fn div_assign(&mut self, other: Self) {
         self.0.div_assign(other.0)
     }
 }
 
 impl<W> Rem for Reverse<W>
-where W: Rem {
+where
+    W: Rem,
+{
     type Output = Reverse<W::Output>;
     fn rem(self, other: Self) -> Self::Output {
         Reverse(self.0.rem(other.0))
@@ -126,7 +155,9 @@ where W: Rem {
 }
 
 impl<W> RemAssign for Reverse<W>
-where W: RemAssign {
+where
+    W: RemAssign,
+{
     fn rem_assign(&mut self, other: Self) {
         self.0.rem_assign(other.0)
     }
@@ -134,7 +165,11 @@ where W: RemAssign {
 
 impl<W: Factorizable> Factorizable for Reverse<W> {
     fn factorize(self, n: usize) -> Vec<Self> {
-        self.0.factorize(n).into_iter().map(|v| Reverse(v)).collect()
+        self.0
+            .factorize(n)
+            .into_iter()
+            .map(|v| Reverse(v))
+            .collect()
     }
 }
 

--- a/src/util/tree.rs
+++ b/src/util/tree.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
 use std::collections::btree_map;
+use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 /// A tree map where each node has a _Gorn address_, i.e. a sequence of integers that describes the
@@ -11,7 +11,9 @@ pub struct GornTree<V> {
 
 impl<V> GornTree<V> {
     pub fn new() -> GornTree<V> {
-        GornTree { map: BTreeMap::new() }
+        GornTree {
+            map: BTreeMap::new(),
+        }
     }
 
     pub fn clear(&mut self) {
@@ -47,7 +49,9 @@ impl<V> GornTree<V> {
     }
 
     pub fn split_off(&mut self, key: &Vec<usize>) -> GornTree<V> {
-        GornTree { map: self.map.split_off(key) }
+        GornTree {
+            map: self.map.split_off(key),
+        }
     }
 
     pub fn keys<'a>(&'a self) -> btree_map::Keys<'a, Vec<usize>, V> {
@@ -115,6 +119,8 @@ impl<V> FromIterator<(Vec<usize>, V)> for GornTree<V> {
     where
         T: IntoIterator<Item = (Vec<usize>, V)>,
     {
-        GornTree { map: iter.into_iter().collect() }
+        GornTree {
+            map: iter.into_iter().collect(),
+        }
     }
 }

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -8,11 +8,11 @@ use log_domain::LogDomain;
 use std::fs::File;
 use std::io::Read;
 
-use rustomata::approximation::ApproximationStrategy;
 use rustomata::approximation::equivalence_classes::EquivalenceRelation;
 use rustomata::approximation::relabel::RlbElement;
-use rustomata::grammars::cfg::*;
+use rustomata::approximation::ApproximationStrategy;
 use rustomata::automata::push_down_automaton::*;
+use rustomata::grammars::cfg::*;
 use rustomata::recognisable::*;
 // TODO: Uncomment once PushDownAutomaton::FromStr has been implemented
 // use rustomata::recognisable::automaton::Automaton;
@@ -75,7 +75,9 @@ fn test_cfg_from_str_correctness() {
     };
     let rule_s1 = CFGRule {
         head: String::from("S"),
-        composition: CFGComposition { composition: vec![] },
+        composition: CFGComposition {
+            composition: vec![],
+        },
         weight: LogDomain::new(0.6).unwrap(),
     };
     let control_grammar = CFG {

--- a/tests/pmcfg.rs
+++ b/tests/pmcfg.rs
@@ -183,7 +183,7 @@ fn test_pmcfg_from_str_correctness() {
 
 #[test]
 fn test_tree_stack_automaton_from_str() {
-    use TreeStackInstruction::{Up, Down, Push};
+    use crate::TreeStackInstruction::{Up, Down, Push};
 
     let unprocessed_transitions = vec![
         (

--- a/tests/pmcfg.rs
+++ b/tests/pmcfg.rs
@@ -8,15 +8,15 @@ use std::fs::File;
 use std::io::Read;
 use std::rc::Rc;
 
-use rustomata::approximation::ApproximationStrategy;
 use rustomata::approximation::equivalence_classes::EquivalenceRelation;
 use rustomata::approximation::relabel::RlbElement;
 use rustomata::approximation::tts::TTSElement;
-use rustomata::grammars::pmcfg::*;
-use rustomata::grammars::pmcfg::negra::{to_negra, DumpMode};
-use rustomata::recognisable::*;
-use rustomata::recognisable::coarse_to_fine::CoarseToFineRecogniser;
+use rustomata::approximation::ApproximationStrategy;
 use rustomata::automata::tree_stack_automaton::*;
+use rustomata::grammars::pmcfg::negra::{to_negra, DumpMode};
+use rustomata::grammars::pmcfg::*;
+use rustomata::recognisable::coarse_to_fine::CoarseToFineRecogniser;
+use rustomata::recognisable::*;
 
 fn pmcfg_from_file(grammar_file_path: &str) -> PMCFG<String, String, LogDomain<f64>> {
     let mut grammar_file = File::open(grammar_file_path).unwrap();
@@ -66,9 +66,7 @@ fn test_coarse_to_fine_recogniser_correctness() {
     let tts = TTSElement::new();
     let rel: EquivalenceRelation<String, String> = "0 [A, B]\n1 *".parse().unwrap();
     let mapping = |ps: &PosState<_>| {
-        ps.map(|r: &PMCFGRule<_, _, _>| {
-            r.map_nonterminals(|nt| rel.project(nt))
-        })
+        ps.map(|r: &PMCFGRule<_, _, _>| r.map_nonterminals(|nt| rel.project(nt)))
     };
     let rlb = RlbElement::new(&mapping);
     let recogniser = coarse_to_fine_recogniser!(automaton.clone(); tts, rlb);
@@ -115,14 +113,12 @@ fn test_pmcfg_from_str_correctness() {
         head: String::from("S"),
         tail: vec![String::from("A"), String::from("B")],
         composition: Composition {
-            composition: vec![
-                vec![
-                    VarT::Var(0, 0),
-                    VarT::Var(1, 0),
-                    VarT::Var(0, 1),
-                    VarT::Var(1, 1),
-                ],
-            ],
+            composition: vec![vec![
+                VarT::Var(0, 0),
+                VarT::Var(1, 0),
+                VarT::Var(0, 1),
+                VarT::Var(1, 1),
+            ]],
         },
         weight: LogDomain::new(1.0).unwrap(),
     };
@@ -140,7 +136,9 @@ fn test_pmcfg_from_str_correctness() {
     let rule_a1 = PMCFGRule {
         head: String::from("A"),
         tail: vec![],
-        composition: Composition { composition: vec![vec![], vec![]] },
+        composition: Composition {
+            composition: vec![vec![], vec![]],
+        },
         weight: LogDomain::new(0.5).unwrap(),
     };
     let rule_b0 = PMCFGRule {
@@ -157,7 +155,9 @@ fn test_pmcfg_from_str_correctness() {
     let rule_b1 = PMCFGRule {
         head: String::from("B"),
         tail: vec![],
-        composition: Composition { composition: vec![vec![], vec![]] },
+        composition: Composition {
+            composition: vec![vec![], vec![]],
+        },
         weight: LogDomain::new(0.5).unwrap(),
     };
     let control_grammar = PMCFG {
@@ -183,7 +183,7 @@ fn test_pmcfg_from_str_correctness() {
 
 #[test]
 fn test_tree_stack_automaton_from_str() {
-    use crate::TreeStackInstruction::{Up, Down, Push};
+    use crate::TreeStackInstruction::{Down, Push, Up};
 
     let unprocessed_transitions = vec![
         (
@@ -193,7 +193,7 @@ fn test_tree_stack_automaton_from_str() {
                 current_val: 1.to_string(),
                 new_val: 2.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -202,7 +202,7 @@ fn test_tree_stack_automaton_from_str() {
                 current_val: 1.to_string(),
                 new_val: 3.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -211,7 +211,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 18.to_string(),
                 new_val: 19.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -220,7 +220,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 6.to_string(),
                 new_val: 5.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -229,7 +229,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 7.to_string(),
                 new_val: 8.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "d",
@@ -239,7 +239,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 10.to_string(),
                 new_val: 11.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "d",
@@ -249,7 +249,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 5.to_string(),
                 new_val: 9.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -259,7 +259,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 2.to_string(),
                 new_val: 13.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -269,7 +269,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 14.to_string(),
                 new_val: 15.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "c",
@@ -279,7 +279,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 13.to_string(),
                 new_val: 10.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "c",
@@ -289,7 +289,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 16.to_string(),
                 new_val: 6.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -298,7 +298,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 9.to_string(),
                 new_val: 17.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -307,7 +307,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 8.to_string(),
                 new_val: 4.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "b",
@@ -317,7 +317,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 2.to_string(),
                 new_val: 13.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "b",
@@ -327,7 +327,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 14.to_string(),
                 new_val: 15.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -336,7 +336,7 @@ fn test_tree_stack_automaton_from_str() {
                 current_val: 18.to_string(),
                 new_val: 1.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -345,7 +345,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 9.to_string(),
                 new_val: 17.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -354,7 +354,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 8.to_string(),
                 new_val: 4.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -363,7 +363,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 3.to_string(),
                 new_val: 14.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -372,7 +372,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 1.to_string(),
                 new_val: 12.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -382,7 +382,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 10.to_string(),
                 new_val: 11.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -392,7 +392,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 5.to_string(),
                 new_val: 9.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "a",
@@ -401,7 +401,7 @@ fn test_tree_stack_automaton_from_str() {
                 current_val: 3.to_string(),
                 new_val: 2.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "a",
@@ -410,7 +410,7 @@ fn test_tree_stack_automaton_from_str() {
                 current_val: 3.to_string(),
                 new_val: 3.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -419,7 +419,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 15.to_string(),
                 new_val: 16.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -428,7 +428,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 12.to_string(),
                 new_val: 7.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -437,7 +437,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 6.to_string(),
                 new_val: 5.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -446,7 +446,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 7.to_string(),
                 new_val: 8.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -456,7 +456,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 13.to_string(),
                 new_val: 10.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -466,7 +466,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 16.to_string(),
                 new_val: 6.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -475,7 +475,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 3.to_string(),
                 new_val: 14.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -484,7 +484,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 1.to_string(),
                 new_val: 12.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -493,7 +493,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 15.to_string(),
                 new_val: 16.to_string(),
             },
-            1.0
+            1.0,
         ),
         (
             "",
@@ -502,7 +502,7 @@ fn test_tree_stack_automaton_from_str() {
                 old_val: 12.to_string(),
                 new_val: 7.to_string(),
             },
-            1.0
+            1.0,
         ),
     ];
 

--- a/unique-heap/src/lib.rs
+++ b/unique-heap/src/lib.rs
@@ -1,5 +1,5 @@
-use std::collections::{ BinaryHeap, HashSet, hash_map::RandomState };
-use std::hash::{ BuildHasher, Hash };
+use std::collections::{hash_map::RandomState, BinaryHeap, HashSet};
+use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 
 #[cfg(feature = "fnvtype")]
@@ -29,23 +29,23 @@ pub struct UniqueHeap<It, Wt, Bh = RandomState>
 where
     Wt: Ord,
     It: Ord + Hash,
-    Bh: BuildHasher
+    Bh: BuildHasher,
 {
     heap: BinaryHeap<(Wt, It)>,
-    current_items: HashSet<It, Bh>
+    current_items: HashSet<It, Bh>,
 }
 
 impl<It, Wt, Bh> UniqueHeap<It, Wt, Bh>
 where
     It: Ord + Hash,
     Wt: Ord,
-    Bh: BuildHasher
+    Bh: BuildHasher,
 {
     /// Pushes an element onto the heap, if it is not present.
     /// This method returns true, if the element was pushed.
     pub fn push(&mut self, item: It, weight: Wt) -> bool
     where
-        It: Clone
+        It: Clone,
     {
         if self.current_items.insert(item.clone()) {
             self.heap.push((weight, item));
@@ -54,7 +54,7 @@ where
             false
         }
     }
-    
+
     /// Pops from the heap.
     pub fn pop(&mut self) -> Option<(It, Wt)> {
         if let Some((weight, item)) = self.heap.pop() {
@@ -86,10 +86,13 @@ impl<I, W, B> Default for UniqueHeap<I, W, B>
 where
     B: Default + BuildHasher,
     I: Ord + Hash,
-    W: Ord
+    W: Ord,
 {
     fn default() -> Self {
-        UniqueHeap{ heap: BinaryHeap::default(), current_items: HashSet::default() }
+        UniqueHeap {
+            heap: BinaryHeap::default(),
+            current_items: HashSet::default(),
+        }
     }
 }
 
@@ -97,27 +100,30 @@ impl<I, W, B> FromIterator<(I, W)> for UniqueHeap<I, W, B>
 where
     I: Ord + Hash + Clone,
     W: Ord,
-    B: BuildHasher + Default
+    B: BuildHasher + Default,
 {
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (I, W)>
+        T: IntoIterator<Item = (I, W)>,
     {
         let iter = iter.into_iter();
         let n = match iter.size_hint() {
             (_, Some(upper)) => upper,
-            (lower, None) => lower
+            (lower, None) => lower,
         };
         let mut heap = BinaryHeap::with_capacity(n);
         let mut current_items = HashSet::with_capacity_and_hasher(n, Default::default());
-        
+
         for (item, weight) in iter {
             if current_items.insert(item.clone()) {
                 heap.push((weight, item));
             }
         }
 
-        UniqueHeap { heap, current_items }
+        UniqueHeap {
+            heap,
+            current_items,
+        }
     }
 }
 
@@ -125,11 +131,14 @@ impl<I, W, B> From<Vec<(W, I)>> for UniqueHeap<I, W, B>
 where
     I: Ord + Hash + Clone,
     W: Ord,
-    B: BuildHasher + Default
+    B: BuildHasher + Default,
 {
     fn from(vec: Vec<(W, I)>) -> Self {
         let current_items = vec.iter().map(|(_, i)| i).cloned().collect();
-        UniqueHeap { heap: vec.into(), current_items }
+        UniqueHeap {
+            heap: vec.into(),
+            current_items,
+        }
     }
 }
 
@@ -137,7 +146,7 @@ impl<I, W, B> IntoIterator for UniqueHeap<I, W, B>
 where
     I: Ord + Hash + Clone,
     W: Ord,
-    B: BuildHasher
+    B: BuildHasher,
 {
     type IntoIter = ::std::collections::binary_heap::IntoIter<(W, I)>;
     type Item = (W, I);
@@ -151,10 +160,10 @@ impl<'a, I, W, B> IntoIterator for &'a UniqueHeap<I, W, B>
 where
     I: Ord + Hash + Clone + 'a,
     W: Ord + 'a,
-    B: BuildHasher + 'a
+    B: BuildHasher + 'a,
 {
     type IntoIter = ::std::collections::binary_heap::Iter<'a, (W, I)>;
-    type Item =  &'a (W, I);
+    type Item = &'a (W, I);
 
     fn into_iter(self) -> Self::IntoIter {
         self.heap.iter()

--- a/vecmultimap/src/lib.rs
+++ b/vecmultimap/src/lib.rs
@@ -6,9 +6,11 @@ pub struct VecMultiMapAdapter<'a, T>(pub &'a mut Vec<Vec<T>>);
 
 impl<'a, T> VecMultiMapAdapter<'a, T> {
     fn pad_to(&mut self, index: usize) {
-        if index >= self.0.len() { self.0.resize_with(index + 1, Vec::new) }
+        if index >= self.0.len() {
+            self.0.resize_with(index + 1, Vec::new)
+        }
     }
-    
+
     pub fn push_to(&mut self, index: usize, value: T) {
         self.pad_to(index);
         self.0[index].push(value);
@@ -18,7 +20,7 @@ impl<'a, T> VecMultiMapAdapter<'a, T> {
         self.pad_to(index);
         unsafe { self.0.get_unchecked(index) }
     }
-    
+
     pub fn get_or_fail(&self, index: usize) -> Option<&Vec<T>> {
         self.0.get(index)
     }
@@ -30,10 +32,14 @@ impl<'a, T> VecMultiMapAdapter<'a, T> {
 }
 
 impl<T> VecMultiMap<T> {
-    pub fn new() -> Self { VecMultiMap(Vec::new()) }
+    pub fn new() -> Self {
+        VecMultiMap(Vec::new())
+    }
 
     fn pad_to(&mut self, index: usize) {
-        if index >= self.0.len() { self.0.resize_with(index + 1, Vec::new) }
+        if index >= self.0.len() {
+            self.0.resize_with(index + 1, Vec::new)
+        }
     }
 
     pub fn push_to(&mut self, index: usize, value: T) {
@@ -45,7 +51,7 @@ impl<T> VecMultiMap<T> {
         self.pad_to(index);
         unsafe { self.0.get_unchecked(index) }
     }
-    
+
     pub fn get_or_fail(&self, index: usize) -> Option<&Vec<T>> {
         self.0.get(index)
     }
@@ -62,13 +68,16 @@ impl<T> VecMultiMap<T> {
 }
 
 impl<'a, T> From<&'a mut Vec<Vec<T>>> for VecMultiMapAdapter<'a, T> {
-    fn from(v: &'a mut Vec<Vec<T>>) -> Self { Self(v) }
+    fn from(v: &'a mut Vec<Vec<T>>) -> Self {
+        Self(v)
+    }
 }
 
 impl<T> Into<Vec<Vec<T>>> for VecMultiMap<T> {
     fn into(self) -> Vec<Vec<T>> {
         // find greatest index with non-empty vector
-        if let Some((last_filled_index, _)) = self.0.iter().enumerate().rfind(|(_, v)| v.len() > 0) {
+        if let Some((last_filled_index, _)) = self.0.iter().enumerate().rfind(|(_, v)| v.len() > 0)
+        {
             self.into_vec_with_size(last_filled_index + 1)
         } else {
             Vec::new()
@@ -76,11 +85,11 @@ impl<T> Into<Vec<Vec<T>>> for VecMultiMap<T> {
     }
 }
 
-
 impl<'a, T> Index<usize> for VecMultiMapAdapter<'a, T> {
     type Output = Vec<T>;
     fn index(&self, index: usize) -> &Self::Output {
-        self.get_or_fail(index).expect("immutable index out of bounds")
+        self.get_or_fail(index)
+            .expect("immutable index out of bounds")
     }
 }
 impl<'a, T> IndexMut<usize> for VecMultiMapAdapter<'a, T> {


### PR DESCRIPTION
When I took a look at the code I couldn't help but seeing that the code in this repository is based on Rust 2015 and has a few issues related to formatting etc. so I took the freedom to run
```
cargo fix --edition
cargo fmt
```

to transform the code and make it more idiomatic or readable. This also fixes a number of issues with the code itself, though some remain.

I understand this PR is somewhat extensive and may be a bit "too much" but if you consider it to be too much of a change, feel free to just close it. :)